### PR TITLE
Team B Android: Metadata & Bugfixes

### DIFF
--- a/src/common/crypto/mod.rs
+++ b/src/common/crypto/mod.rs
@@ -1,3 +1,6 @@
+use algorithms::encryption::{AsymmetricEncryption, BlockCiphers};
+use algorithms::hashes::Hash;
+
 pub mod algorithms;
 pub mod pkcs;
 
@@ -8,4 +11,13 @@ pub enum KeyUsage {
     Decrypt,
     SignEncrypt,
     CreateX509,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum EncryptionMode {
+    Sym(BlockCiphers),
+    ASym {
+        algo: AsymmetricEncryption,
+        digest: Hash,
+    },
 }

--- a/src/common/crypto/mod.rs
+++ b/src/common/crypto/mod.rs
@@ -21,3 +21,8 @@ pub enum EncryptionMode {
         digest: Hash,
     },
 }
+
+pub struct Capability {
+    pub name: &'static str,
+    pub mode: EncryptionMode,
+}

--- a/src/common/factory.rs
+++ b/src/common/factory.rs
@@ -101,6 +101,17 @@ impl SecModules {
         instances.get(&module).cloned()
     }
 
+    /// Retrieves the capabilities of a security module based on the provided type.
+    /// This function delegates the capability retrieval to the specific module's implementation.
+    /// Capabilities are currently an array of encryption modes supported by the module.
+    /// # Arguments
+    ///
+    /// * `module` - The `SecurityModule` variant representing the type of module to retrieve capabilities for.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<Capability>` containing the encryption modes supported by the module.
+    /// If the module type is not supported, an empty vector is returned.
     pub fn get_capabilities(module: SecurityModule) -> Vec<Capability> {
         match module {
             #[cfg(feature = "hsm")]

--- a/src/common/factory.rs
+++ b/src/common/factory.rs
@@ -118,6 +118,8 @@ impl SecModules {
             SecurityModule::Hsm(hsm_type) => HsmInstance::get_capabilities(hsm_type),
             #[cfg(feature = "tpm")]
             SecurityModule::Tpm(tpm_type) => TpmInstance::get_capabilities(tpm_type),
+            #[cfg(feature = "nks")]
+            SecurityModule::Nks => todo!("NKS capabilities"),
         }
     }
 }

--- a/src/common/factory.rs
+++ b/src/common/factory.rs
@@ -1,5 +1,5 @@
 use super::{
-    crypto::EncryptionMode,
+    crypto::Capability,
     traits::{log_config::LogConfig, module_provider::Provider},
 };
 #[cfg(feature = "hsm")]
@@ -101,7 +101,7 @@ impl SecModules {
         instances.get(&module).cloned()
     }
 
-    pub fn get_capabilities(module: SecurityModule) -> Vec<EncryptionMode> {
+    pub fn get_capabilities(module: SecurityModule) -> Vec<Capability> {
         match module {
             #[cfg(feature = "hsm")]
             SecurityModule::Hsm(hsm_type) => HsmInstance::get_capabilities(hsm_type),

--- a/src/common/factory.rs
+++ b/src/common/factory.rs
@@ -1,4 +1,7 @@
-use super::traits::{log_config::LogConfig, module_provider::Provider};
+use super::{
+    crypto::EncryptionMode,
+    traits::{log_config::LogConfig, module_provider::Provider},
+};
 #[cfg(feature = "hsm")]
 use crate::hsm::core::instance::{HsmInstance, HsmType};
 #[cfg(feature = "tpm")]
@@ -26,7 +29,6 @@ pub enum SecurityModule {
     Tpm(TpmType),
     #[cfg(feature = "nks")]
     Nks,
-
 }
 
 /// Provides conversion from a string slice to a `SecurityModule` variant.
@@ -98,6 +100,15 @@ impl SecModules {
 
         instances.get(&module).cloned()
     }
+
+    pub fn get_capabilities(module: SecurityModule) -> Vec<EncryptionMode> {
+        match module {
+            #[cfg(feature = "hsm")]
+            SecurityModule::Hsm(hsm_type) => HsmInstance::get_capabilities(hsm_type),
+            #[cfg(feature = "tpm")]
+            SecurityModule::Tpm(tpm_type) => TpmInstance::get_capabilities(tpm_type),
+        }
+    }
 }
 
 /// Represents a specific instance of a security module.
@@ -137,7 +148,9 @@ impl SecModule {
             SecurityModule::Tpm(tpm_type) => Some(TpmInstance::create_instance(key_id, tpm_type)),
             // _ => unimplemented!(),
             #[cfg(feature = "nks")]
-            SecurityModule::Nks => Some(Arc::new(Mutex::new(crate::nks::hcvault::NksProvider::new(key_id)))),
+            SecurityModule::Nks => Some(Arc::new(Mutex::new(
+                crate::nks::hcvault::NksProvider::new(key_id),
+            ))),
         }
     }
 }

--- a/src/hsm/core/instance.rs
+++ b/src/hsm/core/instance.rs
@@ -1,3 +1,4 @@
+use crate::common::crypto::EncryptionMode;
 use crate::common::traits::module_provider::Provider;
 use std::sync::{Arc, Mutex};
 
@@ -94,6 +95,13 @@ impl HsmInstance {
     /// reference-counting pointer.
     pub fn create_instance(_key_id: String, hpm_type: &HsmType) -> Arc<Mutex<dyn Provider>> {
         match hpm_type {
+            HsmType::YubiKey => todo!(),
+            HsmType::NitroKey => todo!(),
+        }
+    }
+
+    pub fn get_capabilities(hsm_type: HsmType) -> Vec<EncryptionMode> {
+        match hsm_type {
             HsmType::YubiKey => todo!(),
             HsmType::NitroKey => todo!(),
         }

--- a/src/hsm/core/instance.rs
+++ b/src/hsm/core/instance.rs
@@ -1,4 +1,4 @@
-use crate::common::crypto::EncryptionMode;
+use crate::common::crypto::Capability;
 use crate::common::traits::module_provider::Provider;
 use std::sync::{Arc, Mutex};
 
@@ -100,7 +100,7 @@ impl HsmInstance {
         }
     }
 
-    pub fn get_capabilities(hsm_type: HsmType) -> Vec<EncryptionMode> {
+    pub fn get_capabilities(hsm_type: HsmType) -> Vec<Capability> {
         match hsm_type {
             HsmType::YubiKey => todo!(),
             HsmType::NitroKey => todo!(),

--- a/src/tpm/android/android_logger.rs
+++ b/src/tpm/android/android_logger.rs
@@ -5,6 +5,8 @@ use crate::common::traits::log_config::LogConfig;
 #[derive(Debug)]
 pub struct DefaultAndroidLogger;
 
+/// Implements the `LogConfig` trait for the default Android logger.
+/// This logger uses the `tracing-android` crate to log messages to the Android logcat.
 impl LogConfig for DefaultAndroidLogger {
     fn setup_logging(&self) {
         let subscriber = Registry::default().with(tracing_android::layer("RUST").unwrap());

--- a/src/tpm/android/capabilities.rs
+++ b/src/tpm/android/capabilities.rs
@@ -3,22 +3,43 @@ use crate::common::crypto::algorithms::encryption::{
 };
 use crate::common::crypto::algorithms::hashes::{Hash, Sha2Bits};
 use crate::common::crypto::algorithms::KeyBits;
-use crate::common::crypto::EncryptionMode;
+use crate::common::crypto::{Capability, EncryptionMode};
 
-pub fn get_capabilities() -> Vec<EncryptionMode> {
+pub fn get_capabilities() -> Vec<Capability> {
     vec![
-        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cbc, KeyBits::Bits256)),
-        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cfb, KeyBits::Bits256)),
-        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ctr, KeyBits::Bits256)),
-        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ecb, KeyBits::Bits256)),
-        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ofb, KeyBits::Bits256)),
-        EncryptionMode::ASym {
-            algo: AsymmetricEncryption::Rsa(KeyBits::Bits256),
-            digest: Hash::Sha2(Sha2Bits::Sha256),
+        Capability {
+            name: "AES-CBC-256",
+            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cbc, KeyBits::Bits256)),
         },
-        EncryptionMode::ASym {
-            algo: AsymmetricEncryption::Rsa(KeyBits::Bits512),
-            digest: Hash::Sha2(Sha2Bits::Sha256),
+        Capability {
+            name: "AES-CFB-256",
+            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cfb, KeyBits::Bits256)),
+        },
+        Capability {
+            name: "AES-CTR-256",
+            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ctr, KeyBits::Bits256)),
+        },
+        Capability {
+            name: "AES-ECB-256",
+            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ecb, KeyBits::Bits256)),
+        },
+        Capability {
+            name: "AES-OFB-256",
+            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ofb, KeyBits::Bits256)),
+        },
+        Capability {
+            name: "RSA-256",
+            mode: EncryptionMode::ASym {
+                algo: AsymmetricEncryption::Rsa(KeyBits::Bits256),
+                digest: Hash::Sha2(Sha2Bits::Sha256),
+            },
+        },
+        Capability {
+            name: "RSA-512",
+            mode: EncryptionMode::ASym {
+                algo: AsymmetricEncryption::Rsa(KeyBits::Bits512),
+                digest: Hash::Sha2(Sha2Bits::Sha256),
+            },
         },
     ]
 }

--- a/src/tpm/android/capabilities.rs
+++ b/src/tpm/android/capabilities.rs
@@ -1,0 +1,24 @@
+use crate::common::crypto::algorithms::encryption::{
+    AsymmetricEncryption, BlockCiphers, SymmetricMode,
+};
+use crate::common::crypto::algorithms::hashes::{Hash, Sha2Bits};
+use crate::common::crypto::algorithms::KeyBits;
+use crate::common::crypto::EncryptionMode;
+
+pub fn get_capabilities() -> Vec<EncryptionMode> {
+    vec![
+        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cbc, KeyBits::Bits256)),
+        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cfb, KeyBits::Bits256)),
+        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ctr, KeyBits::Bits256)),
+        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ecb, KeyBits::Bits256)),
+        EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ofb, KeyBits::Bits256)),
+        EncryptionMode::ASym {
+            algo: AsymmetricEncryption::Rsa(KeyBits::Bits256),
+            digest: Hash::Sha2(Sha2Bits::Sha256),
+        },
+        EncryptionMode::ASym {
+            algo: AsymmetricEncryption::Rsa(KeyBits::Bits512),
+            digest: Hash::Sha2(Sha2Bits::Sha256),
+        },
+    ]
+}

--- a/src/tpm/android/capabilities.rs
+++ b/src/tpm/android/capabilities.rs
@@ -17,25 +17,35 @@ pub fn get_capabilities() -> Vec<Capability> {
             mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cbc, KeyBits::Bits128)),
         },
         Capability {
-            name: "ENC-AES-CBC-192",
-            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cbc, KeyBits::Bits192)),
-        },
-        Capability {
             name: "ENC-DESede-CBC",
             mode: EncryptionMode::Sym(BlockCiphers::TripleDes(TripleDesNumKeys::Tdes2)),
         },
         Capability {
-            name: "ENC-RSA-512",
+            name: "ENC-RSA-1024-256",
             mode: EncryptionMode::ASym {
-                algo: AsymmetricEncryption::Rsa(KeyBits::Bits512),
+                algo: AsymmetricEncryption::Rsa(KeyBits::Bits1024),
                 digest: Hash::Sha2(Sha2Bits::Sha256),
             },
         },
         Capability {
-            name: "ENC-RSA-512-512",
+            name: "ENC-RSA-2048-256",
             mode: EncryptionMode::ASym {
-                algo: AsymmetricEncryption::Rsa(KeyBits::Bits512),
-                digest: Hash::Sha2(Sha2Bits::Sha512),
+                algo: AsymmetricEncryption::Rsa(KeyBits::Bits2048),
+                digest: Hash::Sha2(Sha2Bits::Sha256),
+            },
+        },
+        Capability {
+            name: "SIG-RSA-1024-256",
+            mode: EncryptionMode::ASym {
+                algo: AsymmetricEncryption::Rsa(KeyBits::Bits1024),
+                digest: Hash::Sha2(Sha2Bits::Sha256),
+            },
+        },
+        Capability {
+            name: "SIG-RSA-2048-256",
+            mode: EncryptionMode::ASym {
+                algo: AsymmetricEncryption::Rsa(KeyBits::Bits2048),
+                digest: Hash::Sha2(Sha2Bits::Sha256),
             },
         },
         Capability {
@@ -43,13 +53,6 @@ pub fn get_capabilities() -> Vec<Capability> {
             mode: EncryptionMode::ASym {
                 algo: AsymmetricEncryption::Ecc(EccSchemeAlgorithm::EcDsa(EccCurves::Secp256k1)),
                 digest: Hash::Sha2(Sha2Bits::Sha256),
-            },
-        },
-        Capability {
-            name: "SIG-EC-DSA-512",
-            mode: EncryptionMode::ASym {
-                algo: AsymmetricEncryption::Ecc(EccSchemeAlgorithm::EcDsa(EccCurves::Secp256k1)),
-                digest: Hash::Sha2(Sha2Bits::Sha512),
             },
         },
     ]

--- a/src/tpm/android/capabilities.rs
+++ b/src/tpm/android/capabilities.rs
@@ -1,5 +1,6 @@
 use crate::common::crypto::algorithms::encryption::{
-    AsymmetricEncryption, BlockCiphers, SymmetricMode,
+    AsymmetricEncryption, BlockCiphers, EccCurves, EccSchemeAlgorithm, SymmetricMode,
+    TripleDesNumKeys,
 };
 use crate::common::crypto::algorithms::hashes::{Hash, Sha2Bits};
 use crate::common::crypto::algorithms::KeyBits;
@@ -8,37 +9,47 @@ use crate::common::crypto::{Capability, EncryptionMode};
 pub fn get_capabilities() -> Vec<Capability> {
     vec![
         Capability {
-            name: "AES-CBC-256",
+            name: "ENC-AES-CBC-256",
             mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cbc, KeyBits::Bits256)),
         },
         Capability {
-            name: "AES-CFB-256",
-            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cfb, KeyBits::Bits256)),
+            name: "ENC-AES-CBC-128",
+            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cbc, KeyBits::Bits128)),
         },
         Capability {
-            name: "AES-CTR-256",
-            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ctr, KeyBits::Bits256)),
+            name: "ENC-AES-CBC-192",
+            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Cbc, KeyBits::Bits192)),
         },
         Capability {
-            name: "AES-ECB-256",
-            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ecb, KeyBits::Bits256)),
+            name: "ENC-DESede-CBC",
+            mode: EncryptionMode::Sym(BlockCiphers::TripleDes(TripleDesNumKeys::Tdes2)),
         },
         Capability {
-            name: "AES-OFB-256",
-            mode: EncryptionMode::Sym(BlockCiphers::Aes(SymmetricMode::Ofb, KeyBits::Bits256)),
-        },
-        Capability {
-            name: "RSA-256",
+            name: "ENC-RSA-512",
             mode: EncryptionMode::ASym {
-                algo: AsymmetricEncryption::Rsa(KeyBits::Bits256),
+                algo: AsymmetricEncryption::Rsa(KeyBits::Bits512),
                 digest: Hash::Sha2(Sha2Bits::Sha256),
             },
         },
         Capability {
-            name: "RSA-512",
+            name: "ENC-RSA-512-512",
             mode: EncryptionMode::ASym {
                 algo: AsymmetricEncryption::Rsa(KeyBits::Bits512),
+                digest: Hash::Sha2(Sha2Bits::Sha512),
+            },
+        },
+        Capability {
+            name: "SIG-EC-DSA-256",
+            mode: EncryptionMode::ASym {
+                algo: AsymmetricEncryption::Ecc(EccSchemeAlgorithm::EcDsa(EccCurves::Secp256k1)),
                 digest: Hash::Sha2(Sha2Bits::Sha256),
+            },
+        },
+        Capability {
+            name: "SIG-EC-DSA-512",
+            mode: EncryptionMode::ASym {
+                algo: AsymmetricEncryption::Ecc(EccSchemeAlgorithm::EcDsa(EccCurves::Secp256k1)),
+                digest: Hash::Sha2(Sha2Bits::Sha512),
             },
         },
     ]

--- a/src/tpm/android/config.rs
+++ b/src/tpm/android/config.rs
@@ -3,22 +3,9 @@ use std::any::Any;
 use robusta_jni::jni::JavaVM;
 
 use crate::common::{
-    crypto::{
-        algorithms::encryption::{AsymmetricEncryption, BlockCiphers},
-        algorithms::hashes::Hash,
-        KeyUsage,
-    },
+    crypto::{EncryptionMode, KeyUsage},
     traits::module_provider_config::ProviderConfig,
 };
-
-#[derive(Debug, Clone, Copy)]
-pub enum EncryptionMode {
-    Sym(BlockCiphers),
-    ASym {
-        algo: AsymmetricEncryption,
-        digest: Hash,
-    },
-}
 
 pub struct AndroidConfig {
     pub mode: EncryptionMode,

--- a/src/tpm/android/config.rs
+++ b/src/tpm/android/config.rs
@@ -7,10 +7,18 @@ use crate::common::{
     traits::module_provider_config::ProviderConfig,
 };
 
+/// Represents the configuration for the Android provider.
 pub struct AndroidConfig {
+    /// The encryption mode used by the provider.
     pub mode: EncryptionMode,
+    /// The allowed key usages for the provider.
     pub key_usages: Vec<KeyUsage>,
+    /// Indicates whether keys should be hardware-backed. If `true`, keys are stored in secure
+    /// hardware. If the hardware does not support hardware-backed keys, all operations will fail.
     pub hardware_backed: bool,
+    /// A Java VM instance used to interact with the Android Keystore.
+    /// While in most cases the Java VM can be retrieved programmatically, it is recommended to
+    /// provide it explicitly to avoid potential issues.
     pub vm: Option<JavaVM>,
 }
 

--- a/src/tpm/android/mod.rs
+++ b/src/tpm/android/mod.rs
@@ -406,9 +406,7 @@ impl KeyHandle for AndroidProvider {
             }
             config::EncryptionMode::ASym { algo: _, digest: _ } => {
                 let key = key_store
-                    .getCertificate(&env, self.key_id.to_owned())
-                    .err_internal()?
-                    .getPublicKey(&env)
+                    .getKey(&env, self.key_id.to_owned(), JObject::null())
                     .err_internal()?;
                 cipher.init(&env, 2, key.raw.as_obj()).err_internal()?;
 

--- a/src/tpm/android/mod.rs
+++ b/src/tpm/android/mod.rs
@@ -287,7 +287,7 @@ impl KeyHandle for AndroidProvider {
     /// # Returns
     ///
     /// Returns a `Result` containing the signed data as a `Vec<u8>` if successful, or a `SecurityModuleError` if an error occurs.
-    #[instrument]
+    #[instrument(skip(data))]
     fn sign_data(&self, data: &[u8]) -> Result<Vec<u8>, SecurityModuleError> {
         // check that signing is allowed
         let config = self
@@ -360,7 +360,7 @@ impl KeyHandle for AndroidProvider {
     /// # Returns
     ///
     /// Returns a `Result` containing the decrypted data as a `Vec<u8>` if successful, or a `SecurityModuleError` if an error occurs.
-    #[instrument]
+    #[instrument(skip(encrypted_data))]
     fn decrypt_data(&self, encrypted_data: &[u8]) -> Result<Vec<u8>, SecurityModuleError> {
         info!("decrypting data");
 
@@ -442,7 +442,7 @@ impl KeyHandle for AndroidProvider {
     /// # Returns
     ///
     /// Returns a `Result` containing the encrypted data as a `Vec<u8>` if successful, or a `SecurityModuleError` if an error occurs.
-    #[instrument]
+    #[instrument(skip(data))]
     fn encrypt_data(&self, data: &[u8]) -> Result<Vec<u8>, SecurityModuleError> {
         info!("encrypting");
 
@@ -529,7 +529,7 @@ impl KeyHandle for AndroidProvider {
     /// # Returns
     ///
     /// Returns a `Result` containing `true` if the signature is valid, `false` otherwise, or a `SecurityModuleError` if an error occurs.
-    #[instrument]
+    #[instrument(skip(data, signature))]
     fn verify_signature(&self, data: &[u8], signature: &[u8]) -> Result<bool, SecurityModuleError> {
         info!("verifiying");
 

--- a/src/tpm/android/mod.rs
+++ b/src/tpm/android/mod.rs
@@ -17,7 +17,7 @@ use utils::{
 };
 use wrapper::key_generation::iv_parameter_spec::jni::IvParameterSpec;
 
-use crate::common::crypto::{EncryptionMode, KeyUsage};
+use crate::common::crypto::{Capability, EncryptionMode, KeyUsage};
 use crate::common::error::SecurityModuleError;
 use crate::common::traits::key_handle::KeyHandle;
 use crate::common::{
@@ -70,7 +70,7 @@ impl AndroidProvider {
         Ok(())
     }
 
-    pub fn get_capabilities() -> Vec<EncryptionMode> {
+    pub fn get_capabilities() -> Vec<Capability> {
         get_capabilities()
     }
 }

--- a/src/tpm/android/mod.rs
+++ b/src/tpm/android/mod.rs
@@ -498,8 +498,6 @@ impl KeyHandle for AndroidProvider {
                 cipher.doFinal(&env, data.to_vec()).err_internal()?
             }
         };
-
-        debug!("encrypted: {:?}", encrypted);
         Ok(encrypted)
     }
 

--- a/src/tpm/android/mod.rs
+++ b/src/tpm/android/mod.rs
@@ -10,7 +10,7 @@ use std::any::Any;
 
 use capabilities::get_capabilities;
 use robusta_jni::jni::objects::JObject;
-use tracing::{debug, info, instrument};
+use tracing::{debug, instrument};
 use utils::{
     get_algorithm, get_cipher_mode, get_digest, get_iv_len, get_key_size, get_padding,
     get_signature_algorithm, get_signature_padding, get_sym_block_mode, load_iv, store_iv,

--- a/src/tpm/android/utils.rs
+++ b/src/tpm/android/utils.rs
@@ -2,16 +2,17 @@
 
 use crate::{
     common::{
-        crypto::algorithms::{
-            encryption::{AsymmetricEncryption, BlockCiphers, SymmetricMode},
-            hashes::{Hash, Sha2Bits},
+        crypto::{
+            algorithms::{
+                encryption::{AsymmetricEncryption, BlockCiphers, SymmetricMode},
+                hashes::{Hash, Sha2Bits},
+            },
+            EncryptionMode,
         },
         error::SecurityModuleError,
     },
     tpm::core::error::TpmError,
 };
-
-use super::config::EncryptionMode;
 
 pub fn get_algorithm(enc: EncryptionMode) -> Result<String, SecurityModuleError> {
     Ok(match enc {

--- a/src/tpm/android/wrapper/key_store/cipher.rs
+++ b/src/tpm/android/wrapper/key_store/cipher.rs
@@ -68,7 +68,7 @@ pub mod jni {
             env.call_method(
                 self.raw.as_obj(),
                 "init",
-                "(ILjava/security/Key;Ljava/security/AlgorithmParameters;)V",
+                "(ILjava/security/Key;Ljava/security/spec/AlgorithmParameterSpec;)V",
                 &[
                     JValue::Int(opmode),
                     JValue::Object(key.raw.as_obj()),

--- a/src/tpm/core/instance.rs
+++ b/src/tpm/core/instance.rs
@@ -138,6 +138,18 @@ impl TpmInstance {
         }
     }
 
+    /// Retrieves the capabilities of a TPM provider based on the specified `TpmType`.
+    /// This method delegates the capability retrieval to the specific provider's implementation.
+    /// Capabilities are currently an array of encryption modes supported by the provider.
+    /// # Arguments
+    ///
+    /// * `tpm_type` - The `TpmType` variant representing the type of TPM to retrieve capabilities for.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<Capability>` containing the encryption modes supported by the provider.
+    ///
+    /// If the TPM type is not supported, an empty vector is returned.
     pub fn get_capabilities(tpm_type: TpmType) -> Vec<Capability> {
         match tpm_type {
             #[cfg(feature = "win")]

--- a/src/tpm/core/instance.rs
+++ b/src/tpm/core/instance.rs
@@ -3,7 +3,7 @@ use crate::tpm::linux::TpmProvider;
 #[cfg(feature = "win")]
 use crate::tpm::win::TpmProvider as WinTpmProvider;
 use crate::{
-    common::{crypto::EncryptionMode, traits::module_provider::Provider},
+    common::{crypto::Capability, traits::module_provider::Provider},
     tpm::android::AndroidProvider,
 };
 use std::sync::{Arc, Mutex};
@@ -138,7 +138,7 @@ impl TpmInstance {
         }
     }
 
-    pub fn get_capabilities(tpm_type: TpmType) -> Vec<EncryptionMode> {
+    pub fn get_capabilities(tpm_type: TpmType) -> Vec<Capability> {
         match tpm_type {
             #[cfg(feature = "win")]
             TpmType::Windows => todo!(),

--- a/src/tpm/core/instance.rs
+++ b/src/tpm/core/instance.rs
@@ -1,8 +1,11 @@
-use crate::common::traits::module_provider::Provider;
 #[cfg(feature = "linux")]
 use crate::tpm::linux::TpmProvider;
 #[cfg(feature = "win")]
 use crate::tpm::win::TpmProvider as WinTpmProvider;
+use crate::{
+    common::{crypto::EncryptionMode, traits::module_provider::Provider},
+    tpm::android::AndroidProvider,
+};
 use std::sync::{Arc, Mutex};
 
 /// Represents the different environments where a Trusted Platform Module (TPM) can operate.
@@ -131,6 +134,20 @@ impl TpmInstance {
                 )),
                 AndroidTpmType::Knox => todo!(),
             },
+            TpmType::None => todo!(),
+        }
+    }
+
+    pub fn get_capabilities(tpm_type: TpmType) -> Vec<EncryptionMode> {
+        match tpm_type {
+            #[cfg(feature = "win")]
+            TpmType::Windows => todo!(),
+            #[cfg(feature = "macos")]
+            TpmType::MacOs => todo!(),
+            #[cfg(feature = "linux")]
+            TpmType::Linux => todo!(),
+            TpmType::Android(AndroidTpmType::Keystore) => AndroidProvider::get_capabilities(),
+            TpmType::Android(AndroidTpmType::Knox) => todo!(),
             TpmType::None => todo!(),
         }
     }


### PR DESCRIPTION
This PR adds the ability to retrieve metadata in form of the available algorithms for the selected SecurityModule.

The SecModules struct now has the function `get_capabilities(module: SecurityModule) -> Vec<Capability>`,
which returns a list of all available Capabilities. A Capability is a struct that includes the canonical name of an algorithm and the algorithm itself in form of the new EncryptionMode enum.

EncryptionMode bundles symmetric and asymmetric encryption into a simple enum, allowing easy description of a specific algorithm and additional data.

`get_capabilities` delegates its function to the selected ModuleProvider, similar to `get_instance`.
The Android Provider implements this with a hard coded list of allowed Capabilities that were verified to work on multiple Android Devices. It should be possible to replace this naive implementation with either an in memory database or to retrieve these Capabilities from the device itself.

Additionally multiple bugs that were found through testing were fixed and the pentest feedback was integrated.