### PR TITLE
Fix Errors when Creating RSA Key with Windows TPM Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /.idea/vcs.xml
 /.idea/.gitignore
 /.idea/*
+/logs

--- a/src/tests/tpm/win/provider_handle_tests.rs
+++ b/src/tests/tpm/win/provider_handle_tests.rs
@@ -22,7 +22,7 @@ fn test_create_rsa_key() {
     let mut provider = TpmProvider::new("test_rsa_key".to_string());
 
     let config = TpmConfig::new(
-        Some(AsymmetricEncryption::Rsa(KeyBits::Bits4096)),
+        Some(AsymmetricEncryption::Rsa(KeyBits::Bits2048)),
         Some(BlockCiphers::Aes(SymmetricMode::Gcm, KeyBits::Bits512)),
         Some(Hash::Sha2(Sha2Bits::Sha256)),
         vec![

--- a/src/tpm/win/mod.rs
+++ b/src/tpm/win/mod.rs
@@ -122,3 +122,14 @@ impl From<AsymmetricEncryption> for PCWSTR {
         }
     }
 }
+
+/// Wraps NCrypt function calls with unsafe block, potential [`Error`](windows::core::Error) with [`TpmError`](crate::tpm::core::error::TpmError) and returns said error if any.
+macro_rules! execute_ncrypt_function {
+    ($cng_function:expr) => {
+        if let Err(e) = unsafe { $cng_function } {
+            return Err(TpmError::Win(e).into());
+        }
+    };
+}
+
+pub(self) use execute_ncrypt_function;


### PR DESCRIPTION
This PR mainly focuses on getting the test `crate::tests::tpm::win::test_create_rsa_key` to work.