### PR TITLE
refactor(common)!: create provider

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -46,4 +46,14 @@ pub struct ProviderConfig {
 #[derive(Clone, Copy, Debug)]
 pub enum ProviderImplConfig {
     Android {},
+    Stub {},
+}
+
+impl ProviderImplConfig {
+    pub(super) fn name(&self) -> String {
+        match self {
+            ProviderImplConfig::Android {} => "ANDROID_PROVIDER".to_owned(),
+            ProviderImplConfig::Stub {} => "STUB_PROVIDER".to_owned(),
+        }
+    }
 }

--- a/src/common/traits/module_provider.rs
+++ b/src/common/traits/module_provider.rs
@@ -7,14 +7,14 @@ use crate::common::{
 };
 
 #[async_trait]
-pub trait ProviderFactory {
+pub trait ProviderFactory: Send + Sync {
     fn get_name(&self) -> String;
 
     /// Returns security level and supported algorithms of a provider.
     ///
     /// [ProviderConfig] returned stores in HashSets all Hashes, Ciphers and AsymmetricKeySpecs a provider supports.
-    async fn get_capabilities(&mut self, impl_config: ProviderImplConfig) -> ProviderConfig;
-    async fn create_provider(self, impl_config: ProviderImplConfig) -> Box<dyn ProviderImpl>;
+    async fn get_capabilities(&self, impl_config: ProviderImplConfig) -> ProviderConfig;
+    async fn create_provider(&self, impl_config: ProviderImplConfig) -> Box<dyn ProviderImpl>;
 }
 
 /// Defines the interface for a security module provider.

--- a/src/stub/mod.rs
+++ b/src/stub/mod.rs
@@ -25,7 +25,7 @@ impl ProviderFactory for StubProviderFactory {
         return PROVIDER_NAME.to_owned();
     }
 
-    async fn get_capabilities(&mut self, impl_config: ProviderImplConfig) -> ProviderConfig {
+    async fn get_capabilities(&self, impl_config: ProviderImplConfig) -> ProviderConfig {
         return ProviderConfig {
             min_security_level: SecurityLevel::Software,
             max_security_level: SecurityLevel::Software,
@@ -35,7 +35,7 @@ impl ProviderFactory for StubProviderFactory {
         };
     }
 
-    async fn create_provider(self, impl_config: ProviderImplConfig) -> Box<dyn ProviderImpl> {
+    async fn create_provider(&self, impl_config: ProviderImplConfig) -> Box<dyn ProviderImpl> {
         return Box::new(StubProvider {});
     }
 }


### PR DESCRIPTION
This PR tries to streamline the use of `create_provider`:
* `create_provider` takes a Vec instead of a HashMap.
* Added a `name` function for `ProviderImplConfig` enum.