### PR TITLE
Test(clippy): Added Lints for Edition 2024 Compability and Other Common Problems

### DIFF
--- a/src/common/factory.rs
+++ b/src/common/factory.rs
@@ -74,7 +74,7 @@ fn provider_supports_capabilities(
 ///     supported_ciphers: HashSet::new(),
 ///     supported_hashes: HashSet::new(),
 /// };
-/// let provider = create_provider(provider_config, specific_provider_config).unwrap();
+/// let provider = create_provider(&provider_config, specific_provider_config).unwrap();
 /// ```
 pub fn create_provider(conf: &ProviderConfig, impl_conf: ProviderImplConfig) -> Option<Provider> {
     for provider in ALL_PROVIDERS.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,16 @@
 //!
 //!
 
+#![warn(
+    rust_2024_incompatible_pat,
+    rust_2024_prelude_collisions,
+    clippy::suspicious,
+    clippy::perf,
+    clippy::cargo
+)]
+#![deny(clippy::correctness)]
+//#![allow(dead_code)]
+
 /// Public module holding the API of the library and common structs.
 pub mod common;
 #[cfg(feature = "ffi")]


### PR DESCRIPTION


### Added:
* Lints for rust edition 2024 compatibility. 
* Lints for correctness and other matters.

### Changed:
* Fixed error in doctest.

### Removed:


### Checklist:
* [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
* [x] Are changes in common propagated to all providers that are currently in use? 
    * [x] `software`
    * [x] `tpm/android`
    * [x] `tpm/apple_secure_enclave`
* [x] Did changes in the API occur, such that `./ts-types` needs to be updated?
* [x] Does the node plugin (`./node-plugin`) still compile?
* [x] Do the dart bindings have to be re-generated?
* [x] Does the flutter plugin still compile?
* [x] Do the integration tests in flutter-app still run?
* [x] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
