### PR TITLE
Fix(node plugin): Panic on Empty Typed Array or Empty Slice

### DIFF
--- a/node-plugin/crates/crypto-layer-node/src/dhexchange.rs
+++ b/node-plugin/crates/crypto-layer-node/src/dhexchange.rs
@@ -1,10 +1,10 @@
 use std::cell::RefCell;
 
 use neon::prelude::*;
-use neon::types::buffer::TypedArray;
 
 use crate::common::Finalized;
 use crate::fromjs::error::unwrap_or_throw;
+use crate::fromjs::vec_from_uint_8_array;
 use crate::{JsDhExchange, JsKeyHandle};
 
 /// Wraps `get_public_key` function.
@@ -38,7 +38,7 @@ pub fn export_add_external(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let dh_exchange_js = cx.this::<JsDhExchange>()?;
     let mut dh_exchange = dh_exchange_js.borrow_mut();
     let raw_public_key_js = cx.argument::<JsUint8Array>(0)?;
-    let raw_public_key = raw_public_key_js.as_slice(&cx).to_vec();
+    let raw_public_key = vec_from_uint_8_array(&mut cx, raw_public_key_js);
 
     let new_raw_key = unwrap_or_throw!(cx, dh_exchange.add_external(&raw_public_key));
 
@@ -59,7 +59,7 @@ pub fn export_add_external_final(mut cx: FunctionContext) -> JsResult<JsKeyHandl
     let dh_exchange_js = cx.this::<JsDhExchange>()?;
     let mut dh_exchange = dh_exchange_js.borrow_mut();
     let raw_public_key_js = cx.argument::<JsUint8Array>(0)?;
-    let raw_public_key = raw_public_key_js.as_slice(&cx).to_vec();
+    let raw_public_key = vec_from_uint_8_array(&mut cx, raw_public_key_js);
 
     let key_handle = unwrap_or_throw!(cx, dh_exchange.add_external_final(&raw_public_key));
 

--- a/node-plugin/crates/crypto-layer-node/src/dhexchange.rs
+++ b/node-plugin/crates/crypto-layer-node/src/dhexchange.rs
@@ -5,6 +5,7 @@ use neon::prelude::*;
 use crate::common::Finalized;
 use crate::fromjs::error::unwrap_or_throw;
 use crate::fromjs::vec_from_uint_8_array;
+use crate::tojs::uint_8_array_from_vec_u8;
 use crate::{JsDhExchange, JsKeyHandle};
 
 /// Wraps `get_public_key` function.
@@ -21,7 +22,7 @@ pub fn export_get_public_key(mut cx: FunctionContext) -> JsResult<JsUint8Array> 
     let handle = handle_js.borrow();
 
     let public_key = unwrap_or_throw!(cx, handle.get_public_key());
-    Ok(JsUint8Array::from_slice(&mut cx, &public_key)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, public_key)?)
 }
 
 /// Wraps `add_external` function.
@@ -42,7 +43,7 @@ pub fn export_add_external(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
 
     let new_raw_key = unwrap_or_throw!(cx, dh_exchange.add_external(&raw_public_key));
 
-    Ok(JsUint8Array::from_slice(&mut cx, &new_raw_key)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, new_raw_key)?)
 }
 
 /// Wraps `add_external_final` function.

--- a/node-plugin/crates/crypto-layer-node/src/fromjs/mod.rs
+++ b/node-plugin/crates/crypto-layer-node/src/fromjs/mod.rs
@@ -8,6 +8,7 @@ use std::hash::Hash;
 use std::str::FromStr;
 
 use neon::prelude::*;
+use neon::types::buffer::TypedArray;
 use tracing::error;
 
 use error::{js_result, ConversionError};
@@ -29,6 +30,19 @@ pub(crate) fn from_wrapped_string_vec<'a>(
     }
 
     Ok(res)
+}
+
+/// Converts any `Uint8Array` into a `Vec<u8>`.
+pub(crate) fn vec_from_uint_8_array(
+    cx: &mut FunctionContext,
+    typed_js_array: Handle<JsUint8Array>,
+) -> Vec<u8> {
+    if typed_js_array.len(cx) == 0 {
+        vec![]
+    } else {
+        // `as_slice` method panics on empty array.
+        typed_js_array.as_slice(cx).to_vec()
+    }
 }
 
 /// Returns all keys of an JS Object.

--- a/node-plugin/crates/crypto-layer-node/src/keyhandle.rs
+++ b/node-plugin/crates/crypto-layer-node/src/keyhandle.rs
@@ -3,6 +3,7 @@ use neon::prelude::*;
 use crate::fromjs::error::unwrap_or_throw;
 use crate::fromjs::vec_from_uint_8_array;
 use crate::tojs::config::wrap_key_spec;
+use crate::tojs::uint_8_array_from_vec_u8;
 use crate::JsKeyHandle;
 
 /// Wraps `id` function.
@@ -57,11 +58,7 @@ pub fn export_encrypt_data(mut cx: FunctionContext) -> JsResult<JsArray> {
     let arr = cx.empty_array();
     let encrypted_data_js = JsUint8Array::from_slice(&mut cx, &encrypted_data)?;
     arr.set(&mut cx, 0, encrypted_data_js)?;
-    let iv_js = if iv.len() == 0 {
-        JsUint8Array::new(&mut cx, 0)?
-    } else {
-        JsUint8Array::from_slice(&mut cx, &iv)?
-    };
+    let iv_js = uint_8_array_from_vec_u8(&mut cx, iv)?;
     arr.set(&mut cx, 1, iv_js)?;
     Ok(arr)
 }
@@ -86,7 +83,7 @@ pub fn export_decrypt_data(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let iv = vec_from_uint_8_array(&mut cx, iv_js);
 
     let decrypted_data = unwrap_or_throw!(cx, handle.decrypt_data(&data, &iv));
-    Ok(JsUint8Array::from_slice(&mut cx, &decrypted_data)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, decrypted_data)?)
 }
 
 /// Wraps `extract_key` function.
@@ -103,7 +100,7 @@ pub fn export_extract_key(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let handle = handle_js.borrow();
 
     let key = unwrap_or_throw!(cx, handle.extract_key());
-    Ok(JsUint8Array::from_slice(&mut cx, &key)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, key)?)
 }
 
 /// Wraps `spec` function.

--- a/node-plugin/crates/crypto-layer-node/src/keypairhandle.rs
+++ b/node-plugin/crates/crypto-layer-node/src/keypairhandle.rs
@@ -1,7 +1,7 @@
 use neon::prelude::*;
-use neon::types::buffer::TypedArray;
 
 use crate::error::unwrap_or_throw;
+use crate::fromjs::vec_from_uint_8_array;
 use crate::tojs::config::wrap_key_pair_spec;
 use crate::JsKeyPairHandle;
 
@@ -17,11 +17,12 @@ use crate::JsKeyPairHandle;
 /// * When failing to execute.
 pub fn export_sign_data(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let handle_js = cx.this::<JsKeyPairHandle>()?;
-    let mut data_js = cx.argument::<JsUint8Array>(0)?;
+    let data_js = cx.argument::<JsUint8Array>(0)?;
 
-    let data = data_js.as_mut_slice(&mut cx);
+    let data = vec_from_uint_8_array(&mut cx, data_js);
     let handle = handle_js.borrow();
-    let signature = unwrap_or_throw!(cx, handle.sign_data(data));
+
+    let signature = unwrap_or_throw!(cx, handle.sign_data(&data));
     Ok(JsUint8Array::from_slice(&mut cx, &signature)?)
 }
 
@@ -38,13 +39,13 @@ pub fn export_sign_data(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
 /// * When failing to execute.
 pub fn export_verify_data(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let handle_js = cx.this::<JsKeyPairHandle>()?;
-    let mut data_js = cx.argument::<JsUint8Array>(0)?;
-    let mut signature_js = cx.argument::<JsUint8Array>(1)?;
+    let data_js = cx.argument::<JsUint8Array>(0)?;
+    let signature_js = cx.argument::<JsUint8Array>(1)?;
 
-    let data = Vec::from(data_js.as_mut_slice(&mut cx));
-    let signature = signature_js.as_mut_slice(&mut cx);
+    let data = vec_from_uint_8_array(&mut cx, data_js);
+    let signature = vec_from_uint_8_array(&mut cx, signature_js);
     let handle = handle_js.borrow();
-    let res = unwrap_or_throw!(cx, handle.verify_signature(&data, signature));
+    let res = unwrap_or_throw!(cx, handle.verify_signature(&data, &signature));
     Ok(cx.boolean(res))
 }
 
@@ -95,9 +96,9 @@ pub fn export_encrypt_data(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let handle_js = cx.this::<JsKeyPairHandle>()?;
     let handle = handle_js.borrow();
     let data_js = cx.argument::<JsUint8Array>(0)?;
-    let data = data_js.as_slice(&mut cx);
+    let data = vec_from_uint_8_array(&mut cx, data_js);
 
-    let encrypted_data = unwrap_or_throw!(cx, handle.encrypt_data(data));
+    let encrypted_data = unwrap_or_throw!(cx, handle.encrypt_data(&data));
     Ok(JsUint8Array::from_slice(&mut cx, &encrypted_data)?)
 }
 
@@ -115,9 +116,9 @@ pub fn export_decrypt_data(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let handle_js = cx.this::<JsKeyPairHandle>()?;
     let handle = handle_js.borrow();
     let data_js = cx.argument::<JsUint8Array>(0)?;
-    let data = data_js.as_slice(&mut cx);
+    let data = vec_from_uint_8_array(&mut cx, data_js);
 
-    let decrypted_data = unwrap_or_throw!(cx, handle.decrypt_data(data));
+    let decrypted_data = unwrap_or_throw!(cx, handle.decrypt_data(&data));
     Ok(JsUint8Array::from_slice(&mut cx, &decrypted_data)?)
 }
 

--- a/node-plugin/crates/crypto-layer-node/src/keypairhandle.rs
+++ b/node-plugin/crates/crypto-layer-node/src/keypairhandle.rs
@@ -3,6 +3,7 @@ use neon::prelude::*;
 use crate::error::unwrap_or_throw;
 use crate::fromjs::vec_from_uint_8_array;
 use crate::tojs::config::wrap_key_pair_spec;
+use crate::tojs::uint_8_array_from_vec_u8;
 use crate::JsKeyPairHandle;
 
 /// Wraps `sign_data` function.
@@ -23,7 +24,7 @@ pub fn export_sign_data(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let handle = handle_js.borrow();
 
     let signature = unwrap_or_throw!(cx, handle.sign_data(&data));
-    Ok(JsUint8Array::from_slice(&mut cx, &signature)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, signature)?)
 }
 
 /// Wraps `verify_data` function.
@@ -99,7 +100,7 @@ pub fn export_encrypt_data(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let data = vec_from_uint_8_array(&mut cx, data_js);
 
     let encrypted_data = unwrap_or_throw!(cx, handle.encrypt_data(&data));
-    Ok(JsUint8Array::from_slice(&mut cx, &encrypted_data)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, encrypted_data)?)
 }
 
 /// Wraps `decrypt_data` function.
@@ -119,7 +120,7 @@ pub fn export_decrypt_data(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let data = vec_from_uint_8_array(&mut cx, data_js);
 
     let decrypted_data = unwrap_or_throw!(cx, handle.decrypt_data(&data));
-    Ok(JsUint8Array::from_slice(&mut cx, &decrypted_data)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, decrypted_data)?)
 }
 
 /// Wraps `get_public_key` function.
@@ -136,7 +137,7 @@ pub fn export_get_public_key(mut cx: FunctionContext) -> JsResult<JsUint8Array> 
     let handle = handle_js.borrow();
 
     let public_key = unwrap_or_throw!(cx, handle.get_public_key());
-    Ok(JsUint8Array::from_slice(&mut cx, &public_key)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, public_key)?)
 }
 
 /// Wraps `extract_key` function.
@@ -153,7 +154,7 @@ pub fn export_extract_key(mut cx: FunctionContext) -> JsResult<JsUint8Array> {
     let handle = handle_js.borrow();
 
     let private_key = unwrap_or_throw!(cx, handle.extract_key());
-    Ok(JsUint8Array::from_slice(&mut cx, &private_key)?)
+    Ok(uint_8_array_from_vec_u8(&mut cx, private_key)?)
 }
 
 /// Wraps `spec` function.

--- a/node-plugin/crates/crypto-layer-node/src/provider.rs
+++ b/node-plugin/crates/crypto-layer-node/src/provider.rs
@@ -1,10 +1,10 @@
 use std::cell::RefCell;
 
 use neon::prelude::*;
-use neon::types::buffer::TypedArray;
 
 use crate::common::Finalized;
 use crate::fromjs::error::unwrap_or_throw;
+use crate::fromjs::vec_from_uint_8_array;
 use crate::tojs::config::wrap_provider_config;
 use crate::{from_wrapped_key_pair_spec, from_wrapped_key_spec};
 use crate::{JsDhExchange, JsKeyHandle, JsKeyPairHandle, JsProvider};
@@ -141,7 +141,7 @@ pub fn export_import_key(mut cx: FunctionContext) -> JsResult<JsKeyHandle> {
     let spec_js = cx.argument::<JsObject>(0)?;
     let spec = unwrap_or_throw!(cx, from_wrapped_key_spec(&mut cx, spec_js));
     let raw_key_js = cx.argument::<JsUint8Array>(1)?;
-    let raw_key = raw_key_js.as_slice(&cx).to_vec();
+    let raw_key = vec_from_uint_8_array(&mut cx, raw_key_js);
 
     let key_handle = unwrap_or_throw!(cx, provider.import_key(spec, &raw_key));
 
@@ -170,9 +170,9 @@ pub fn export_import_key_pair(mut cx: FunctionContext) -> JsResult<JsKeyPairHand
     let spec_js = cx.argument::<JsObject>(0)?;
     let spec = unwrap_or_throw!(cx, from_wrapped_key_pair_spec(&mut cx, spec_js));
     let raw_public_key_js = cx.argument::<JsUint8Array>(1)?;
-    let raw_public_key = raw_public_key_js.as_slice(&cx).to_vec();
+    let raw_public_key = vec_from_uint_8_array(&mut cx, raw_public_key_js);
     let raw_private_key_js = cx.argument::<JsUint8Array>(2)?;
-    let raw_private_key = raw_private_key_js.as_slice(&cx).to_vec();
+    let raw_private_key = vec_from_uint_8_array(&mut cx, raw_private_key_js);
 
     let key_pair_handle = unwrap_or_throw!(
         cx,
@@ -203,7 +203,7 @@ pub fn export_import_public_key(mut cx: FunctionContext) -> JsResult<JsKeyPairHa
     let spec_js = cx.argument::<JsObject>(0)?;
     let spec = unwrap_or_throw!(cx, from_wrapped_key_pair_spec(&mut cx, spec_js));
     let raw_public_key_js = cx.argument::<JsUint8Array>(1)?;
-    let raw_public_key = raw_public_key_js.as_slice(&cx).to_vec();
+    let raw_public_key = vec_from_uint_8_array(&mut cx, raw_public_key_js);
 
     let key_pair_handle = unwrap_or_throw!(cx, provider.import_public_key(spec, &raw_public_key));
 

--- a/node-plugin/crates/crypto-layer-node/src/tojs/mod.rs
+++ b/node-plugin/crates/crypto-layer-node/src/tojs/mod.rs
@@ -12,3 +12,16 @@ pub fn wrap_string_array<'a>(cx: &mut impl Context<'a>, arr: Vec<String>) -> JsR
 
     Ok(result)
 }
+
+/// Converts a `Vec<u8>` into a `Uint8Array`.
+pub(crate) fn uint_8_array_from_vec_u8<'a>(
+    cx: &mut FunctionContext<'a>,
+    value: Vec<u8>,
+) -> NeonResult<Handle<'a, JsUint8Array>> {
+    if value.len() == 0 {
+        JsUint8Array::new(cx, 0)
+    } else {
+        // Panics on empty slice.
+        JsUint8Array::from_slice(cx, &value)
+    }
+}

--- a/node-plugin/tests/key-handle.test.ts
+++ b/node-plugin/tests/key-handle.test.ts
@@ -38,6 +38,9 @@ describe("test key handle methods", () => {
 
         let encrypted_data = key.encryptData(hello_msg);
 
+        console.log("data length: ", encrypted_data[0].length);
+        console.log("iv length: ", encrypted_data[1].length);
+
         let decrypted_data = key.decryptData(...encrypted_data);
 
         expect(Buffer.from(decrypted_data).toString("utf8")).toEqual("Hello World!");

--- a/node-plugin/tests/provider.test.ts
+++ b/node-plugin/tests/provider.test.ts
@@ -93,13 +93,13 @@ describe("test provider methods", () => {
             non_exportable: false,
         };
 
-        let key_pair = provider.createKeyPair(spec);
+        let keyPair = provider.createKeyPair(spec);
 
-        let id = key_pair.id();
+        let id = keyPair.id();
 
-        let loaded_key_pair = provider.loadKeyPair(id);
+        let loadedKeyPair = provider.loadKeyPair(id);
 
-        expect(loaded_key_pair.id()).toEqual(id);
+        expect(loadedKeyPair.id()).toEqual(id);
     });
 
     test("create P256 key pair, export and import public key", () => {
@@ -111,11 +111,44 @@ describe("test provider methods", () => {
             non_exportable: false,
         };
 
-        let key_pair = provider.createKeyPair(spec);
+        let keyPair = provider.createKeyPair(spec);
 
-        let raw_public_key = key_pair.getPublicKey();
+        let rawPublicKey = keyPair.getPublicKey();
 
-        let public_key = provider.importPublicKey(spec, raw_public_key);
+        let publicKey = provider.importPublicKey(spec, rawPublicKey);
+    });
+
+    test("create P256 key pair, export and import key pair", () => {
+        let spec: KeyPairSpec = {
+            asym_spec: "P256",
+            cipher: null,
+            signing_hash: "Sha2_256",
+            ephemeral: false,
+            non_exportable: false,
+        };
+
+        let keyPair = provider.createKeyPair(spec);
+
+        let rawPublicKey = keyPair.getPublicKey();
+        let rawPrivateKey = keyPair.extractKey();
+
+        let importedKeyPair = provider.importKeyPair(spec, rawPublicKey,rawPrivateKey);
+    });
+
+    test("create P256 key pair, export and import private key", () => {
+        let spec: KeyPairSpec = {
+            asym_spec: "P256",
+            cipher: null,
+            signing_hash: "Sha2_256",
+            ephemeral: false,
+            non_exportable: false,
+        };
+
+        let keyPair = provider.createKeyPair(spec);
+
+        let rawPrivateKey = keyPair.extractKey();
+
+        let importedKeyPair = provider.importKeyPair(spec, new Uint8Array(0),rawPrivateKey);
     });
 
     test("get provider name", () => {


### PR DESCRIPTION
### Fixed:
* Panic on empty `Uint8Array`.
* Panic on empty slice `&[u8]`.


### Checklist:
* [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
* [ ] Are changes in common propagated to all providers that are currently in use? 
    * [ ] `software`
    * [ ] `tpm/android`
    * [ ] `tpm/apple_secure_enclave`
* [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
* [x] Does the node plugin (`./node-plugin`) still compile?
* [ ] Do the dart bindings have to be re-generated?
* [ ] Does the flutter plugin still compile?
* [ ] Do the integration tests in flutter-app still run?
* [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
