### PR TITLE
fix(node-plugin): added get provider capabilites function

### DIFF
--- a/node-plugin/crates/crypto-layer-node/src/tojs/mod.rs
+++ b/node-plugin/crates/crypto-layer-node/src/tojs/mod.rs
@@ -2,15 +2,27 @@ pub(crate) mod config;
 
 use neon::prelude::*;
 
-/// Converts a `Vec<String>` to an js array (`string[]`).
-pub fn wrap_string_array<'a>(cx: &mut impl Context<'a>, arr: Vec<String>) -> JsResult<'a, JsArray> {
-    let result = JsArray::new(cx, arr.len());
-    for (i, s) in arr.into_iter().enumerate() {
-        let js_s = JsString::new(cx, s);
-        result.set(cx, i as u32, js_s)?;
+pub fn js_array_from_vec<'a, C, F, T>(
+    cx: &mut C,
+    vector: Vec<T>,
+    convert: F,
+) -> JsResult<'a, JsArray>
+where
+    C: Context<'a>,
+    F: Fn(&mut C, T) -> JsResult<'a, JsValue>,
+{
+    let result = JsArray::new(cx, vector.len());
+    for (i, value) in vector.into_iter().enumerate() {
+        let js_value = convert(cx, value)?;
+        result.set(cx, i as u32, js_value)?;
     }
 
     Ok(result)
+}
+
+/// Converts a `Vec<String>` to an js array (`string[]`).
+pub fn wrap_string_array<'a>(cx: &mut impl Context<'a>, arr: Vec<String>) -> JsResult<'a, JsArray> {
+    js_array_from_vec(cx, arr, |cx, s| Ok(JsString::new(cx, s).upcast()))
 }
 
 /// Converts a `Vec<u8>` into a `Uint8Array`.

--- a/node-plugin/src/index.cts
+++ b/node-plugin/src/index.cts
@@ -1,7 +1,7 @@
 // This module is the CJS entry point for the library.
 
 // The Rust addon.
-export { getAllProviders } from "./load.cjs";
+export { getAllProviders, getProviderCapabilities } from "./load.cjs";
 
 import {
     type Provider,
@@ -54,9 +54,10 @@ type BareDHExchange = {};
 // Use this declaration to assign types to the addon's exports,
 // which otherwise by default are `any`.
 declare module "./load.cjs" {
-    export function getAllProviders(): Promise<string[]>;
+    function getAllProviders(): Promise<string[]>;
     function createBareProvider(config: ProviderConfig, impl_config: ProviderImplConfig): Promise<BareProvider | undefined>;
     function createBareProviderFromName(name: string, impl_config: ProviderImplConfig): Promise<BareProvider | undefined>;
+    function getProviderCapabilities(providerImplConfig: ProviderImplConfig): Promise<[string, ProviderConfig][]>;
 
     function providerName(this: BareProvider): Promise<string>;
     function createBareKey(this: BareProvider, spec: KeySpec): Promise<BareKeyHandle>;

--- a/node-plugin/tests/factory.test.ts
+++ b/node-plugin/tests/factory.test.ts
@@ -1,9 +1,10 @@
 import { test, expect, describe } from "@jest/globals";
 
 import { ProviderConfig, ProviderImplConfig, CreateProviderFromNameFunc, CreateProviderFunc, GetAllProvidersFunc } from "crypto-layer-ts-types";
-import { createProvider, getAllProviders, createProviderFromName } from "../lib/index.cjs";
+import { createProvider, getAllProviders, createProviderFromName, getProviderCapabilities } from "../lib/index.cjs";
 
 import { DB_DIR_PATH, SOFTWARE_PROVIDER_NAME } from "./common";
+import { GetProviderCapabilitiesFunc } from "crypto-layer-ts-types/manual";
 
 describe("test provider factory methods", () => {
     const FACTORY_DB_DIR_PATH = DB_DIR_PATH + "/factory";
@@ -22,7 +23,7 @@ describe("test provider factory methods", () => {
         expect(provider_arr).toContain(SOFTWARE_PROVIDER_NAME);
     });
 
-    test("create simple provider with file store",  async () => {
+    test("create simple provider with file store", async () => {
         let providerImplConfigWithFileStore: ProviderImplConfig = {
             additional_config: [{ FileStoreConfig: { db_dir: FACTORY_DB_DIR_PATH } }, { StorageConfigPass: "1234" }]
         };
@@ -40,5 +41,15 @@ describe("test provider factory methods", () => {
         let _a: GetAllProvidersFunc = getAllProviders;
         let _b: CreateProviderFromNameFunc = createProviderFromName;
         let _c: CreateProviderFunc = createProvider;
+        let _d: GetProviderCapabilitiesFunc = getProviderCapabilities;
+    });
+
+    test("test get provider capabilities", async () => {
+        let emptyProviderConfig: ProviderImplConfig = {
+            additional_config: []
+        };
+        let providerCapsList = await getProviderCapabilities(emptyProviderConfig);
+        expect(providerCapsList).toBeTruthy();
+        expect(providerCapsList.length).toBeGreaterThanOrEqual(0);
     });
 });

--- a/src/common/factory.rs
+++ b/src/common/factory.rs
@@ -126,6 +126,7 @@ pub fn get_all_providers() -> Vec<String> {
         .collect()
 }
 
+/// Returns the names and capabilities of all providers that can be initialized with the given [ProviderImplConfig].
 pub fn get_provider_capabilities(impl_config: ProviderImplConfig) -> Vec<(String, ProviderConfig)> {
     ALL_PROVIDERS
         .iter()

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,8 @@ pub use crate::common::{
         encryption::{AsymmetricKeySpec, Cipher},
         hashes::CryptoHash,
     },
-    factory::{create_provider, create_provider_from_name, get_all_providers},
+    factory::{
+        create_provider, create_provider_from_name, get_all_providers, get_provider_capabilities,
+    },
     DHExchange, KeyHandle, KeyPairHandle, Provider,
 };


### PR DESCRIPTION
Added to prelude as well.

### Added:
* Added `getProviderCapabilites` function in the node plugin.
* Added function to rust prelude.

### Changed:


### Removed:


### Checklist:
* [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
* [ ] Are changes in common propagated to all providers that are currently in use? 
    * [ ] `software`
    * [ ] `tpm/android`
    * [ ] `tpm/apple_secure_enclave`
* [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
* [x] Does the node plugin (`./node-plugin`) still compile?
* [ ] Do the dart bindings have to be re-generated?
* [ ] Does the flutter plugin still compile?
* [ ] Do the integration tests in flutter-app still run?
* [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
