### PR TITLE
feature(android): allow android provider to check context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,6 @@ dependencies = [
  "lazy_static",
  "libloading",
  "nanoid",
- "ndk-context",
  "openssl",
  "pkcs8",
  "pollster",
@@ -1569,12 +1568,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ strip = "symbols"
 
 [features]
 ffi = []
-android = ["dep:robusta_jni", "dep:libloading", "dep:ndk-context"]
+android = ["dep:robusta_jni", "dep:libloading"]
 nks = ["core", "dep:x25519-dalek", "hcvault", "dep:reqwest", "dep:rand", "dep:openssl", "dep:arrayref", "dep:base64", "dep:ed25519-dalek", "dep:sodiumoxide"]
 hcvault = []
 core = []
@@ -90,7 +90,6 @@ bincode = "1.3.3"
 pollster = "0.4.0"
 rmp-serde = "1.3.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-ndk-context = { version = "0.1.1", optional = true }
 ts-rs = { version = "10.0.0", optional = true, features = ["format"] }
 strum = { version = "0.26.3", features = ["derive"] }
 ed25519-compact = { version = "2.1.1", optional = true }

--- a/flutter_plugin/rust/Cargo.lock
+++ b/flutter_plugin/rust/Cargo.lock
@@ -582,7 +582,6 @@ dependencies = [
  "hmac",
  "libloading",
  "nanoid",
- "ndk-context",
  "pkcs8",
  "pollster",
  "redb",

--- a/flutter_plugin/rust/src/lib.rs
+++ b/flutter_plugin/rust/src/lib.rs
@@ -2,6 +2,8 @@ pub mod api;
 mod frb_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
 
 pub use crypto_layer;
+#[cfg(target_os = "android")]
+use crypto_layer::common::initialize_android_context;
 
 #[cfg(target_os = "android")]
 use {
@@ -28,7 +30,7 @@ pub extern "system" fn Java_com_example_cal_1flutter_1app_MyPlugin_init_1android
         env.get_java_vm().and_then(|vm| {
             let vm = vm.get_java_vm_pointer().cast::<c_void>();
             unsafe {
-                ndk_context::initialize_android_context(
+                initialize_android_context(
                     vm,
                     global_ctx.as_obj().into_inner().cast::<c_void>(),
                 );

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -169,6 +169,16 @@ impl CalError {
         }
     }
 
+    pub(crate) fn initialization_error(description: String) -> Self {
+        Self {
+            error_kind: CalErrorKind::InitializationError {
+                description,
+                internal: true,
+            },
+            source: anyhow!("Initialization Error"),
+        }
+    }
+
     pub(crate) fn ephemeral_key_required() -> Self {
         Self {
             error_kind: CalErrorKind::EphermalKeyError,

--- a/src/common/factory.rs
+++ b/src/common/factory.rs
@@ -103,7 +103,7 @@ pub fn create_provider_from_name(name: &str, impl_conf: ProviderImplConfig) -> O
     for provider in ALL_PROVIDERS.iter() {
         let p_name = provider.get_name();
 
-        if p_name == name {
+        if p_name.as_deref() == Some(name) {
             return Some(Provider {
                 implementation: match provider.create_provider(impl_conf) {
                     Ok(p) => p,
@@ -122,7 +122,7 @@ pub fn create_provider_from_name(name: &str, impl_conf: ProviderImplConfig) -> O
 pub fn get_all_providers() -> Vec<String> {
     ALL_PROVIDERS
         .iter()
-        .map(ProviderFactory::get_name)
+        .filter_map(ProviderFactory::get_name)
         .collect()
 }
 
@@ -132,7 +132,7 @@ pub fn get_provider_capabilities(impl_config: ProviderImplConfig) -> Vec<(String
         .iter()
         .filter_map(|fac| {
             fac.get_capabilities(impl_config.clone())
-                .map(|caps| (fac.get_name(), caps))
+                .map(|caps| (fac.get_name().expect("When get_capabilities returned Some, get_name must return Some too. This is an internal error"), caps))
         })
         .collect()
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -265,3 +265,12 @@ impl DHExchange {
         pub fn add_external_final(&mut self, external_key: &[u8]) -> Result<KeyHandle, CalError>;
     }
 }
+
+#[cfg(feature = "android")]
+use crate::tpm::android::wrapper::context;
+#[cfg(feature = "android")]
+use std::ffi::c_void;
+#[cfg(feature = "android")]
+pub unsafe fn initialize_android_context(java_vm: *mut c_void, context_jobject: *mut c_void) {
+    context::initialize_android_context(java_vm, context_jobject);
+}

--- a/src/common/traits/module_provider.rs
+++ b/src/common/traits/module_provider.rs
@@ -18,7 +18,7 @@ use enum_dispatch::enum_dispatch;
 
 #[enum_dispatch(ProviderFactoryEnum)]
 pub(crate) trait ProviderFactory: Send + Sync {
-    fn get_name(&self) -> String;
+    fn get_name(&self) -> Option<String>;
 
     /// Returns security level and supported algorithms of a provider.
     ///

--- a/src/software/mod.rs
+++ b/src/software/mod.rs
@@ -29,8 +29,8 @@ pub(crate) mod provider;
 pub(crate) struct SoftwareProviderFactory {}
 
 impl ProviderFactory for SoftwareProviderFactory {
-    fn get_name(&self) -> String {
-        "SoftwareProvider".to_owned()
+    fn get_name(&self) -> Option<String> {
+        Some("SoftwareProvider".to_owned())
     }
 
     fn get_capabilities(&self, _impl_config: ProviderImplConfig) -> Option<ProviderConfig> {
@@ -61,7 +61,8 @@ impl ProviderFactory for SoftwareProviderFactory {
         &self,
         impl_config: ProviderImplConfig,
     ) -> Result<ProviderImplEnum, CalError> {
-        let storage_manager = StorageManager::new(self.get_name(), &impl_config.additional_config)?;
+        let storage_manager =
+            StorageManager::new(self.get_name().unwrap(), &impl_config.additional_config)?;
         Ok(Into::into(SoftwareProvider {
             impl_config,
             storage_manager,

--- a/src/stub/mod.rs
+++ b/src/stub/mod.rs
@@ -23,8 +23,8 @@ const PROVIDER_NAME: &str = "STUB_PROVIDER";
 pub(crate) struct StubProviderFactory {}
 
 impl ProviderFactory for StubProviderFactory {
-    fn get_name(&self) -> String {
-        PROVIDER_NAME.to_owned()
+    fn get_name(&self) -> Option<String> {
+        Some(PROVIDER_NAME.to_owned())
     }
 
     fn get_capabilities(&self, impl_config: ProviderImplConfig) -> Option<ProviderConfig> {

--- a/src/tpm/android/error.rs
+++ b/src/tpm/android/error.rs
@@ -2,7 +2,10 @@ use anyhow::{anyhow, Context};
 use robusta_jni::jni::JavaVM;
 use tracing::{info, warn};
 
-use crate::common::error::{CalError, ToCalError};
+use crate::{
+    common::error::{CalError, ToCalError},
+    tpm::android::wrapper::context,
+};
 
 #[derive(Debug)]
 pub(crate) struct JavaException(String);
@@ -33,7 +36,7 @@ fn err_internal<T>(res: robusta_jni::jni::errors::Result<T>) -> Result<T, anyhow
         Err(e) => {
             info!("err_internal: {:?}", e);
             // check if a java exception was thrown
-            let vm = ndk_context::android_context().vm();
+            let vm = context::android_context()?.vm();
             let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
             let env = vm.attach_current_thread().err_internal()?;
             if env.exception_check().map_err(anyhow::Error::new)? {

--- a/src/tpm/android/key_handle.rs
+++ b/src/tpm/android/key_handle.rs
@@ -9,7 +9,7 @@ use crate::{
     tpm::android::{
         utils::{get_asym_cipher_mode, get_signature_algorithm, get_sym_cipher_mode},
         wrapper::{
-            self,
+            self, context,
             key_generation::iv_parameter_spec::jni::IvParameterSpec,
             key_store::{signature::jni::Signature, store::jni::KeyStore},
         },
@@ -38,7 +38,7 @@ impl KeyHandleImpl for AndroidKeyHandle {
     fn encrypt_data(&self, data: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError> {
         info!("encrypting");
 
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 
@@ -63,7 +63,7 @@ impl KeyHandleImpl for AndroidKeyHandle {
     }
 
     fn decrypt_data(&self, encrypted_data: &[u8], iv: &[u8]) -> Result<Vec<u8>, CalError> {
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 
@@ -128,7 +128,7 @@ impl KeyPairHandleImpl for AndroidKeyPairHandle {
     fn sign_data(&self, data: &[u8]) -> Result<Vec<u8>, CalError> {
         info!("signing");
 
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 
@@ -158,7 +158,7 @@ impl KeyPairHandleImpl for AndroidKeyPairHandle {
     fn verify_signature(&self, data: &[u8], signature: &[u8]) -> Result<bool, CalError> {
         info!("verifiying");
 
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 
@@ -188,7 +188,7 @@ impl KeyPairHandleImpl for AndroidKeyPairHandle {
     fn encrypt_data(&self, encryped_data: &[u8]) -> Result<Vec<u8>, CalError> {
         info!("encrypting");
 
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 
@@ -217,7 +217,7 @@ impl KeyPairHandleImpl for AndroidKeyPairHandle {
     fn decrypt_data(&self, encrypted_data: &[u8]) -> Result<Vec<u8>, CalError> {
         info!("decrypting");
 
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 
@@ -245,7 +245,7 @@ impl KeyPairHandleImpl for AndroidKeyPairHandle {
     fn get_public_key(&self) -> Result<Vec<u8>, CalError> {
         info!("getting public key");
 
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 
@@ -294,7 +294,7 @@ impl KeyPairHandleImpl for AndroidKeyPairHandle {
 
 impl AndroidKeyHandle {
     fn delete_internal(&mut self) -> Result<(), CalError> {
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 
@@ -309,7 +309,7 @@ impl AndroidKeyHandle {
 
 impl AndroidKeyPairHandle {
     fn delete_internal(&mut self) -> Result<(), CalError> {
-        let vm = ndk_context::android_context().vm();
+        let vm = context::android_context()?.vm();
         let vm = unsafe { JavaVM::from_raw(vm.cast()) }.err_internal()?;
         let env = vm.attach_current_thread().err_internal()?;
 

--- a/src/tpm/android/wrapper/context.rs
+++ b/src/tpm/android/wrapper/context.rs
@@ -4,6 +4,91 @@ use tracing::trace;
 use crate::common::error::{CalError, ToCalError};
 use robusta_jni::jni::objects::JObject;
 
+use std::ffi::c_void;
+
+static mut ANDROID_CONTEXT: Option<AndroidContext> = None;
+
+/// [`AndroidContext`] provides the pointers required to interface with the jni on Android
+/// platforms.
+#[derive(Clone, Copy, Debug)]
+pub struct AndroidContext {
+    java_vm: *mut c_void,
+    context_jobject: *mut c_void,
+}
+
+impl AndroidContext {
+    /// A handle to the `JavaVM` object.
+    ///
+    /// Usage with [__jni__](https://crates.io/crates/jni) crate:
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let ctx = ndk_context::android_context();
+    /// let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) }?;
+    /// let env = vm.attach_current_thread();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn vm(self) -> *mut c_void {
+        self.java_vm
+    }
+
+    /// A handle to an [android.content.Context](https://developer.android.com/reference/android/content/Context).
+    /// In most cases this will be a ptr to an `Activity`, but this isn't guaranteed.
+    ///
+    /// Usage with [__jni__](https://crates.io/crates/jni) crate:
+    /// ```no_run
+    /// # use jni::objects::JObject;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let ctx = ndk_context::android_context();
+    /// let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) }?;
+    /// let context = unsafe { JObject::from_raw(ctx.context().cast()) };
+    /// let env = vm.attach_current_thread()?;
+    /// let class_ctx = env.find_class("android/content/Context")?;
+    /// let audio_service = env.get_static_field(class_ctx, "AUDIO_SERVICE", "Ljava/lang/String;")?;
+    /// let audio_manager = env
+    ///     .call_method(
+    ///         context,
+    ///         "getSystemService",
+    ///         "(Ljava/lang/String;)Ljava/lang/Object;",
+    ///         &[audio_service],
+    ///     )?
+    ///     .l()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn context(self) -> *mut c_void {
+        self.context_jobject
+    }
+}
+
+/// Main entry point to this crate. Returns an [`AndroidContext`].
+pub fn android_context() -> Result<AndroidContext, CalError> {
+    unsafe { ANDROID_CONTEXT }.ok_or(CalError::initialization_error(
+        "Android context not initialized".to_string(),
+    ))
+}
+
+#[allow(static_mut_refs)]
+pub fn is_initialized() -> bool {
+    unsafe { ANDROID_CONTEXT.is_some() }
+}
+
+/// Initializes the [`AndroidContext`]. [`AndroidContext`] is initialized by [__ndk-glue__](https://crates.io/crates/ndk-glue)
+/// before `main` is called.
+///
+/// # Safety
+///
+/// The pointers must be valid and this function must be called exactly once before `main` is
+/// called.
+#[allow(static_mut_refs)]
+pub unsafe fn initialize_android_context(java_vm: *mut c_void, context_jobject: *mut c_void) {
+    let previous = ANDROID_CONTEXT.replace(AndroidContext {
+        java_vm,
+        context_jobject,
+    });
+    assert!(previous.is_none());
+}
+
 #[bridge]
 /// This module contains the JNI bindings for the KeyStore functionality in Android.
 pub(crate) mod jni {
@@ -51,7 +136,7 @@ pub(crate) mod jni {
 #[tracing::instrument]
 pub(crate) fn has_strong_box() -> Result<bool, CalError> {
     trace!("Checking if the device has a strong box");
-    let ctx = ndk_context::android_context();
+    let ctx = android_context()?;
     let vm = unsafe { robusta_jni::jni::JavaVM::from_raw(ctx.vm().cast()) }.err_internal()?;
     let env = vm.attach_current_thread().err_internal()?;
     let context = ctx.context();

--- a/src/tpm/apple_secure_enclave/provider.rs
+++ b/src/tpm/apple_secure_enclave/provider.rs
@@ -76,8 +76,8 @@ fn check_key_pair_spec_for_compatibility(key_spec: &KeyPairSpec) -> Result<(), C
 pub(crate) struct AppleSecureEnclaveFactory {}
 
 impl ProviderFactory for AppleSecureEnclaveFactory {
-    fn get_name(&self) -> String {
-        "APPLE_SECURE_ENCLAVE".to_owned()
+    fn get_name(&self) -> Option<String> {
+        Some("APPLE_SECURE_ENCLAVE".to_owned())
     }
 
     fn get_capabilities(&self, _impl_config: ProviderImplConfig) -> Option<ProviderConfig> {
@@ -88,7 +88,8 @@ impl ProviderFactory for AppleSecureEnclaveFactory {
         &self,
         impl_config: ProviderImplConfig,
     ) -> Result<ProviderImplEnum, CalError> {
-        let storage_manager = StorageManager::new(self.get_name(), &impl_config.additional_config)?;
+        let storage_manager =
+            StorageManager::new(self.get_name().unwrap(), &impl_config.additional_config)?;
 
         Ok(AppleSecureEnclaveProvider { storage_manager }.into())
     }

--- a/ts-types/index.ts
+++ b/ts-types/index.ts
@@ -1,2 +1,3 @@
 export * from "./generated/index";
-export { DHExchange, KeyHandle, KeyPairHandle, Provider, CreateProviderFromNameFunc, CreateProviderFunc, GetAllProvidersFunc, ProviderFactoryFunctions } from "./manual/index";
+export { CreateProviderFromNameFunc, CreateProviderFunc, DHExchange, GetAllProvidersFunc, GetProviderCapabilitiesFunc, KeyHandle, KeyPairHandle, Provider, ProviderFactoryFunctions } from "./manual/index";
+


### PR DESCRIPTION
### Added:
Allow android provider to check if Android context was initialized and return None for `get_name` and `get_capabilities`.

### Changed:
`get_name` return `Option<String>` instead of `String`.

### Removed:


### Checklist:
* [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
* [ ] Are changes in common propagated to all providers that are currently in use? 
    * [ ] `software`
    * [ ] `tpm/android`
    * [ ] `tpm/apple_secure_enclave`
* [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
* [ ] Does the node plugin (`./node-plugin`) still compile?
* [ ] Do the dart bindings have to be re-generated?
* [ ] Does the flutter plugin still compile?
* [ ] Do the integration tests in flutter-app still run?
* [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
