### PR TITLE
Docs: Fix README Headers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,6 @@
     "editor.codeActionsOnSave": {
         "source.organizeImports": "explicit"
     },
-    "files.eol": "\n"
+    "files.eol": "\n",
+    "cmake.sourceDirectory": "M:/DEV/WorkProjects/nmshd2/rust-crypto/flutter_app/linux"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,5 @@
     "editor.codeActionsOnSave": {
         "source.organizeImports": "explicit"
     },
-    "files.eol": "\n",
-    "cmake.sourceDirectory": "M:/DEV/WorkProjects/nmshd2/rust-crypto/flutter_app/linux"
+    "files.eol": "\n"
 }

--- a/flutter_app/README.md
+++ b/flutter_app/README.md
@@ -4,13 +4,13 @@ This repository additionally contains a Flutter native plugin and an example Flu
 
 To run this App, the following tools are reqiuired:
 
-- Rust compiler
-- Rust aarch64-linux-android and armv7-linux-androideabi toolchains
-- cargo-ndk
-- Android Debug Bridge (adb)
-- Flutter
-- Android SDK
-- Android NDK
+-   Rust compiler
+-   Rust aarch64-linux-android and armv7-linux-androideabi toolchains
+-   cargo-ndk
+-   Android Debug Bridge (adb)
+-   Flutter
+-   Android SDK
+-   Android NDK
 
 ## Dependencies
 
@@ -31,11 +31,13 @@ cargo install cargo-ndk
 
 Addidtionally install Flutter and either install Android Studio or Download the Android SDK
 Now you can install the NDK with:
+
 ```
 sdkmanager ndk-bundle
 ```
 
 <a name="run" />
+
 ## Running the App
 
 Get the id of the connected Android device with `flutter devices`, then run the App in debug mode:
@@ -44,6 +46,7 @@ Get the id of the connected Android device with `flutter devices`, then run the 
 cd flutter_app
 flutter run -d $DEVICEID
 ```
+
 This should compile the Rust code and the plugin and start the App on the device.
 
 As Android Emulators don't contain a Secure Element, the App was only tested on real devices.

--- a/flutter_plugin/README.md
+++ b/flutter_plugin/README.md
@@ -9,6 +9,7 @@ This project is a starting point for a Flutter
 a specialized package that includes native code directly invoked with Dart FFI.
 
 <a name="generating" />
+
 ## Generating Dart Bindings
 
 ```
@@ -61,24 +62,24 @@ else
 
 This template uses the following structure:
 
-* `src`: Contains the native source code, and a CmakeFile.txt file for building
-  that source code into a dynamic library.
+-   `src`: Contains the native source code, and a CmakeFile.txt file for building
+    that source code into a dynamic library.
 
-* `lib`: Contains the Dart code that defines the API of the plugin, and which
-  calls into the native code using `dart:ffi`.
+-   `lib`: Contains the Dart code that defines the API of the plugin, and which
+    calls into the native code using `dart:ffi`.
 
-* platform folders (`android`, `ios`, `windows`, etc.): Contains the build files
-  for building and bundling the native code library with the platform application.
+-   platform folders (`android`, `ios`, `windows`, etc.): Contains the build files
+    for building and bundling the native code library with the platform application.
 
 ## Building and bundling native code
 
 The `pubspec.yaml` specifies FFI plugins as follows:
 
 ```yaml
-  plugin:
+plugin:
     platforms:
-      some_platform:
-        ffiPlugin: true
+        some_platform:
+            ffiPlugin: true
 ```
 
 This configuration invokes the native build for the various target platforms
@@ -88,34 +89,34 @@ This can be combined with dartPluginClass, such as when FFI is used for the
 implementation of one platform in a federated plugin:
 
 ```yaml
-  plugin:
+plugin:
     implements: some_other_plugin
     platforms:
-      some_platform:
-        dartPluginClass: SomeClass
-        ffiPlugin: true
+        some_platform:
+            dartPluginClass: SomeClass
+            ffiPlugin: true
 ```
 
 A plugin can have both FFI and method channels:
 
 ```yaml
-  plugin:
+plugin:
     platforms:
-      some_platform:
-        pluginClass: SomeName
-        ffiPlugin: true
+        some_platform:
+            pluginClass: SomeName
+            ffiPlugin: true
 ```
 
 The native build systems that are invoked by FFI (and method channel) plugins are:
 
-* For Android: Gradle, which invokes the Android NDK for native builds.
-  * See the documentation in android/build.gradle.
-* For iOS and MacOS: Xcode, via CocoaPods.
-  * See the documentation in ios/cal_flutter_plugin.podspec.
-  * See the documentation in macos/cal_flutter_plugin.podspec.
-* For Linux and Windows: CMake.
-  * See the documentation in linux/CMakeLists.txt.
-  * See the documentation in windows/CMakeLists.txt.
+-   For Android: Gradle, which invokes the Android NDK for native builds.
+    -   See the documentation in android/build.gradle.
+-   For iOS and MacOS: Xcode, via CocoaPods.
+    -   See the documentation in ios/cal_flutter_plugin.podspec.
+    -   See the documentation in macos/cal_flutter_plugin.podspec.
+-   For Linux and Windows: CMake.
+    -   See the documentation in linux/CMakeLists.txt.
+    -   See the documentation in windows/CMakeLists.txt.
 
 ## Binding to native code
 

--- a/ts-types/README.md
+++ b/ts-types/README.md
@@ -8,19 +8,18 @@ This is an npm package with the ts type defintions of the CAL project.
 npm install 'https://gitpkg.vercel.app/nmshd/rust-crypto/ts-types?main&scripts.postinstall=npm%20i%20--ignore-scripts%20%26%26%20npm%20run%20build'
 ```
 
-
 ## Build Package
 
 1. You need to have rust installed.
 2. You need to have npm or similar installed.
 
 <a name="generation" />
+
 ### Generate the Types
 
 ```
 .\Generate-Types.ps1
 ```
-
 
 ### Build the Package
 
@@ -29,15 +28,16 @@ npm i
 npm run build
 ```
 
-
 ## Usage
 
 Add the npm package as dependecy
+
 ```
 npm add --save ./PathToLib/rust-crypto/ts-types/
 ```
 
 Import the types
+
 ```ts
 import { type EccCurve } from "crypto-layer-ts-types";
 ```


### PR DESCRIPTION
### Added:


### Changed:
* Fixed headings of `README` not rendering correctly.
* Might have some MD lint ongoing.

### Removed:


### Checklist:
* [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
* [ ] Are changes in common propagated to all providers that are currently in use? 
    * [ ] `software`
    * [ ] `tpm/android`
    * [ ] `tpm/apple_secure_enclave`
* [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
	* [ ] [Generate types partially](./ts-types/README.md#generation).
	* [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
* [ ] Do the dart bindings have to be [re-generated](./flutter_plugin/README.md#generating)?
* [ ] Does the flutter plugin still compile?
* [ ] Do the integration tests in flutter-app still [run](./flutter_app/README.md#run)?
* [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
