### PR TITLE
ci(ts-types): added release gh workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,9 +14,9 @@
     * [ ] `tpm/android`
     * [ ] `tpm/apple_secure_enclave`
 * [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
-	* [ ] [Generate types partially](./ts-types/README.md#generation).
+	* [ ] [Generate types partially](../ts-types/README.md#generation).
 	* [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-* [ ] Do the dart bindings have to be [re-generated](./flutter_plugin/README.md#generating)?
+* [ ] Do the dart bindings have to be [re-generated](../flutter_plugin/README.md#generating)?
 * [ ] Does the flutter plugin still compile?
-* [ ] Do the integration tests in flutter-app still [run](./flutter_app/README.md#run)?
+* [ ] Do the integration tests in flutter-app still [run](../flutter_app/README.md#run)?
 * [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+      - name: Build
+        run: |
+          npm i
+          npm run build
+      - name: Publish
+        run: npx enhanced-publish --if-possible --use-preid-as-tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ts-types/README.md
+++ b/ts-types/README.md
@@ -2,12 +2,6 @@
 
 This is an npm package with the ts type defintions of the CAL project.
 
-## Use the Package with [GitPkg](https://gitpkg.vercel.app/)
-
-```
-npm install 'https://gitpkg.vercel.app/nmshd/rust-crypto/ts-types?main&scripts.postinstall=npm%20i%20--ignore-scripts%20%26%26%20npm%20run%20build'
-```
-
 ## Build Package
 
 1. You need to have rust installed.

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@nmshd/crypto-layer-types",
+    "name": "@nmshd/rs-crypto-types",
     "version": "0.1.0",
     "description": "Crypto Layer TS type definitions.",
     "homepage": "https://enmeshed.eu",

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,16 +1,22 @@
 {
-  "name": "crypto-layer-ts-types",
-  "version": "0.1.0",
-  "description": "Crypto Layer TS type definitions.",
-  "main": "./dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc"
-  },
-  "author": "j&s-soft AG",
-  "license": "MIT",
-  "devDependencies": {
-    "@types/node": "^22.9.1",
-    "typescript": "^5.6.3"
-  }
+    "name": "@nmshd/crypto-layer-types",
+    "version": "0.1.0",
+    "description": "Crypto Layer TS type definitions.",
+    "homepage": "https://enmeshed.eu",
+    "repository": "github:nmshd/rust-crypto",
+    "license": "MIT",
+    "author": "j&s-soft AG",
+    "main": "./dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "@types/node": "^22.9.1",
+        "typescript": "^5.6.3"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
+    }
 }


### PR DESCRIPTION
### Added:
* gh workflow for npm release

### Changed:


### Removed:


### Checklist:
* [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
* [ ] Are changes in common propagated to all providers that are currently in use? 
    * [ ] `software`
    * [ ] `tpm/android`
    * [ ] `tpm/apple_secure_enclave`
* [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
	* [ ] [Generate types partially](./ts-types/README.md#generation).
	* [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
* [ ] Do the dart bindings have to be [re-generated](./flutter_plugin/README.md#generating)?
* [ ] Does the flutter plugin still compile?
* [ ] Do the integration tests in flutter-app still [run](./flutter_app/README.md#run)?
* [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
