### PR TITLE
fix(ci): wrong working dir for npm execution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,20 @@
 ### Added:
 
-
 ### Changed:
-
 
 ### Removed:
 
-
 ### Checklist:
-* [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-* [ ] Are changes in common propagated to all providers that are currently in use? 
-    * [ ] `software`
-    * [ ] `tpm/android`
-    * [ ] `tpm/apple_secure_enclave`
-* [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
-	* [ ] [Generate types partially](../ts-types/README.md#generation).
-	* [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-* [ ] Do the dart bindings have to be [re-generated](../flutter_plugin/README.md#generating)?
-* [ ] Does the flutter plugin still compile?
-* [ ] Do the integration tests in flutter-app still [run](../flutter_app/README.md#run)?
-* [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
+
+-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
+-   [ ] Are changes in common propagated to all providers that are currently in use?
+    -   [ ] `software`
+    -   [ ] `tpm/android`
+    -   [ ] `tpm/apple_secure_enclave`
+-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
+    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
+    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
+-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
+-   [ ] Does the flutter plugin still compile?
+-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
+-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,12 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       - name: Build
+        working-directory: ./ts-types
         run: |
           npm i
           npm run build
       - name: Publish
+        working-directory: ./ts-types
         run: npx enhanced-publish --if-possible --use-preid-as-tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/flutter_app/README.md
+++ b/flutter_app/README.md
@@ -36,8 +36,6 @@ Now you can install the NDK with:
 sdkmanager ndk-bundle
 ```
 
-<a name="run" />
-
 ## Running the App
 
 Get the id of the connected Android device with `flutter devices`, then run the App in debug mode:

--- a/flutter_plugin/README.md
+++ b/flutter_plugin/README.md
@@ -8,8 +8,6 @@ This project is a starting point for a Flutter
 [FFI plugin](https://flutter.dev/to/ffi-package),
 a specialized package that includes native code directly invoked with Dart FFI.
 
-<a name="generating" />
-
 ## Generating Dart Bindings
 
 ```

--- a/ts-types/README.md
+++ b/ts-types/README.md
@@ -7,8 +7,6 @@ This is an npm package with the ts type defintions of the CAL project.
 1. You need to have rust installed.
 2. You need to have npm or similar installed.
 
-<a name="generation" />
-
 ### Generate the Types
 
 ```


### PR DESCRIPTION
### Added:


### Changed:
* Fixed wrong working dir for release gh workflow.

### Removed:


### Checklist:
* [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
* [ ] Are changes in common propagated to all providers that are currently in use? 
    * [ ] `software`
    * [ ] `tpm/android`
    * [ ] `tpm/apple_secure_enclave`
* [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
	* [ ] [Generate types partially](../ts-types/README.md#generation).
	* [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
* [ ] Do the dart bindings have to be [re-generated](../flutter_plugin/README.md#generating)?
* [ ] Does the flutter plugin still compile?
* [ ] Do the integration tests in flutter-app still [run](../flutter_app/README.md#run)?
* [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
