### PR TITLE
fix(software): panic when private key is empty on extract key method …

### DIFF
--- a/src/software/key_handle.rs
+++ b/src/software/key_handle.rs
@@ -1,7 +1,7 @@
 use crate::common::{
     config::{KeyPairSpec, KeySpec},
     crypto::algorithms::encryption::AsymmetricKeySpec,
-    error::CalError,
+    error::{CalError, KeyType},
     traits::key_handle::{KeyHandleImpl, KeyPairHandleImpl},
     DHExchange,
 };
@@ -240,7 +240,9 @@ impl KeyPairHandleImpl for SoftwareKeyPairHandle {
 
     fn extract_key(&self) -> Result<Vec<u8>, CalError> {
         if !self.spec.non_exportable {
-            Ok(self.signing_key.clone().unwrap())
+            self.signing_key
+                .clone()
+                .ok_or_else(|| CalError::missing_key(self.key_id.clone(), KeyType::Private))
         } else {
             Err(CalError::failed_operation(
                 "The private key is not exportable".to_string(),


### PR DESCRIPTION
…call

### Added:

### Changed:
* Software key pairs `extract_key` does not panic.

### Removed:

### Checklist:

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
