### PR TITLE
Fix(ts types): Wrong Import

### DIFF
--- a/ts-types/manual/DHExchange.ts
+++ b/ts-types/manual/DHExchange.ts
@@ -1,4 +1,4 @@
-import { KeyHandle } from "../generated";
+import { KeyHandle } from "./";
 
 export type DHExchange = {
     getPublicKey: () => Promise<Uint8Array>;

--- a/ts-types/manual/Provider.ts
+++ b/ts-types/manual/Provider.ts
@@ -1,5 +1,5 @@
-import { DHExchange, KeyPairSpec, KeySpec, ProviderConfig } from "../generated";
-import { KeyHandle, KeyPairHandle } from "./";
+import { KeyPairSpec, KeySpec, ProviderConfig } from "../generated";
+import { KeyHandle, KeyPairHandle, DHExchange } from "./";
 
 export type Provider = {
     createKey: (spec: KeySpec) => Promise<KeyHandle>;

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/rs-crypto-types",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Crypto Layer TS type definitions.",
     "homepage": "https://enmeshed.eu",
     "repository": "github:nmshd/rust-crypto",


### PR DESCRIPTION
### Added:

### Changed:
* Fixed wrong import of generated types instead of manual types.

### Removed:

### Checklist:

-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
