### PR TITLE
Fix/ts type wrong provider derive key

### DIFF
--- a/ts-types/manual/Provider.ts
+++ b/ts-types/manual/Provider.ts
@@ -12,6 +12,6 @@ export type Provider = {
     startEphemeralDhExchange: (spec: KeyPairSpec) => Promise<DHExchange>;
     providerName: () => Promise<string>;
     getCapabilities: () => Promise<ProviderConfig | undefined>;
-    deriveKeyFromPassword: (password: string, salt: Uint8Array, spec: KeyPairSpec) => KeyPairHandle;
-    getRandom: (len: number) => Uint8Array;
+    deriveKeyFromPassword: (password: string, salt: Uint8Array, spec: KeyPairSpec) => Promise<KeyPairHandle>;
+    getRandom: (len: number) => Promise<Uint8Array>;
 };

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/rs-crypto-types",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Crypto Layer TS type definitions.",
     "homepage": "https://enmeshed.eu",
     "repository": "github:nmshd/rust-crypto",


### PR DESCRIPTION
### Added:

### Changed:
* Fix bad `Provider` type definition.

### Removed:

### Checklist:

-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
