### PR TITLE
fix: added keyspec usage in key exchange

### DIFF
--- a/src/software/mod.rs
+++ b/src/software/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     storage::StorageManager,
 };
 use ring::{
-    aead,
+    aead, agreement,
     signature::{
         EcdsaSigningAlgorithm, VerificationAlgorithm, ECDSA_P256_SHA256_ASN1,
         ECDSA_P256_SHA256_ASN1_SIGNING, ECDSA_P384_SHA384_ASN1, ECDSA_P384_SHA384_ASN1_SIGNING,
@@ -107,6 +107,24 @@ impl From<Cipher> for &'static aead::Algorithm {
             Cipher::AesGcm256 => &ring::aead::AES_256_GCM,
             Cipher::ChaCha20Poly1305 => &ring::aead::CHACHA20_POLY1305,
             _ => panic!("Unsupported cipher"), // Handle other cases or return an error
+        }
+    }
+}
+
+impl TryFrom<AsymmetricKeySpec> for &'static agreement::Algorithm {
+    type Error = CalError;
+
+    fn try_from(spec: AsymmetricKeySpec) -> Result<Self, Self::Error> {
+        match spec {
+            AsymmetricKeySpec::P256 => Ok(&agreement::ECDH_P256),
+            AsymmetricKeySpec::P384 => Ok(&agreement::ECDH_P384),
+            AsymmetricKeySpec::Curve25519 => Ok(&agreement::X25519),
+            // Handle other variants or return an error
+            _ => Err(CalError::failed_operation(
+                "Algorithm not supported".to_string(),
+                true,
+                None,
+            )),
         }
     }
 }

--- a/src/tests/software/provider_tests.rs
+++ b/src/tests/software/provider_tests.rs
@@ -27,14 +27,20 @@ mod tests {
             );
 
             // Client creates an instance of SoftwareDHExchange
-            let mut client_exchange =
-                SoftwareDHExchange::new("key_id_client".to_string(), storage_manager.clone())
-                    .unwrap();
+            let mut client_exchange = SoftwareDHExchange::new(
+                "key_id_client".to_string(),
+                storage_manager.clone(),
+                KeyPairSpec::default(),
+            )
+            .unwrap();
 
             // Server creates an instance of SoftwareDHExchange
-            let mut server_exchange =
-                SoftwareDHExchange::new("key_id_server".to_string(), storage_manager.clone())
-                    .unwrap();
+            let mut server_exchange = SoftwareDHExchange::new(
+                "key_id_server".to_string(),
+                storage_manager.clone(),
+                KeyPairSpec::default(),
+            )
+            .unwrap();
 
             // Client gets its public key
             let client_public_key = client_exchange
@@ -93,14 +99,20 @@ mod tests {
             );
 
             // Client creates an instance of SoftwareDHExchange
-            let mut client_exchange =
-                SoftwareDHExchange::new("key_id_client".to_string(), storage_manager.clone())
-                    .unwrap();
+            let mut client_exchange = SoftwareDHExchange::new(
+                "key_id_client".to_string(),
+                storage_manager.clone(),
+                KeyPairSpec::default(),
+            )
+            .unwrap();
 
             // Server creates an instance of SoftwareDHExchange
-            let mut server_exchange =
-                SoftwareDHExchange::new("key_id_server".to_string(), storage_manager.clone())
-                    .unwrap();
+            let mut server_exchange = SoftwareDHExchange::new(
+                "key_id_server".to_string(),
+                storage_manager.clone(),
+                KeyPairSpec::default(),
+            )
+            .unwrap();
 
             // Get public keys
             let client_public_key = client_exchange
@@ -231,8 +243,12 @@ mod tests {
             );
 
             // Client creates an instance of SoftwareDHExchange
-            let mut client_exchange =
-                SoftwareDHExchange::new("key_id_client".to_string(), storage_manager).unwrap();
+            let mut client_exchange = SoftwareDHExchange::new(
+                "key_id_client".to_string(),
+                storage_manager,
+                KeyPairSpec::default(),
+            )
+            .unwrap();
 
             // Generate an invalid public key (too short for X25519)
             let invalid_public_key = vec![1, 2, 3, 4, 5];
@@ -263,13 +279,20 @@ mod tests {
             );
 
             // Client creates an instance of SoftwareDHExchange
-            let mut client_exchange =
-                SoftwareDHExchange::new("key_id_client".to_string(), storage_manager.clone())
-                    .unwrap();
+            let mut client_exchange = SoftwareDHExchange::new(
+                "key_id_client".to_string(),
+                storage_manager.clone(),
+                KeyPairSpec::default(),
+            )
+            .unwrap();
 
             // Generate a valid server public key
-            let server_exchange =
-                SoftwareDHExchange::new("key_id_server".to_string(), storage_manager).unwrap();
+            let server_exchange = SoftwareDHExchange::new(
+                "key_id_server".to_string(),
+                storage_manager,
+                KeyPairSpec::default(),
+            )
+            .unwrap();
             let server_public_key = server_exchange.get_public_key().unwrap();
 
             // Client derives session keys once
@@ -306,24 +329,32 @@ mod tests {
             );
 
             // Client1 creates an instance of SoftwareDHExchange
-            let mut client1_exchange =
-                SoftwareDHExchange::new("key_id_client1".to_string(), storage_manager.clone())
-                    .unwrap();
+            let mut client1_exchange = SoftwareDHExchange::new(
+                "key_id_client1".to_string(),
+                storage_manager.clone(),
+                KeyPairSpec::default(),
+            )
+            .unwrap();
 
             // Client2 creates an instance of SoftwareDHExchange
-            let mut client2_exchange =
-                SoftwareDHExchange::new("key_id_client2".to_string(), storage_manager.clone())
-                    .unwrap();
+            let mut client2_exchange = SoftwareDHExchange::new(
+                "key_id_client2".to_string(),
+                storage_manager.clone(),
+                KeyPairSpec::default(),
+            )
+            .unwrap();
 
             // Server instances for each client
             let mut server_for_client1 = SoftwareDHExchange::new(
                 "key_id_server_for_client1".to_string(),
                 storage_manager.clone(),
+                KeyPairSpec::default(),
             )
             .unwrap();
             let mut server_for_client2 = SoftwareDHExchange::new(
                 "key_id_server_for_client2".to_string(),
                 storage_manager.clone(),
+                KeyPairSpec::default(),
             )
             .unwrap();
 


### PR DESCRIPTION
### Added:

### Changed:
Added keyspec usage to key exchange
### Removed:

### Checklist:

-   [X] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [X] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
