### PR TITLE
fix: panic when KeyPairSpec supplied in dh exchange has no cipher spe…

### DIFF
--- a/src/software/provider.rs
+++ b/src/software/provider.rs
@@ -684,13 +684,20 @@ impl SoftwareDHExchange {
         // Generate a unique key ID
         let key_id = format!("{}_{}", self.key_id, key_id_suffix);
 
+        let cipher = self.spec.cipher.ok_or_else(
+            || CalError::bad_parameter(
+                "derive_client_key_handles and derive_server_key_handles need a KeyPairSpec supplied which cipher is not None.".to_owned(), 
+            true, 
+            None
+        ))?;
+
         // Create a SoftwareKeyHandle with the derived key
         let handle = SoftwareKeyHandle {
             key_id,
             key: key_material,
             storage_manager: self.storage_manager.clone(),
             spec: KeySpec {
-                cipher: self.spec.cipher.unwrap(),
+                cipher,
                 ephemeral: self.spec.ephemeral,
                 signing_hash: self.spec.signing_hash,
             },


### PR DESCRIPTION
…cified.

### Added:

### Changed:

### Removed:

### Checklist:

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
