### PR TITLE
fix: fixed bug in generate_session_keys of SoftwareDHExchange

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -176,7 +176,7 @@ impl Provider {
         pub fn get_random(&self, len: usize) -> Vec<u8>;
     }
 
-    delegate_enum_bare! {
+    delegate_enum! {
         pub fn hash(&self, input: &[u8], hash: CryptoHash) -> Result<Vec<u8>, CalError> ;
     }
 }

--- a/src/tests/software/provider_tests.rs
+++ b/src/tests/software/provider_tests.rs
@@ -654,6 +654,8 @@ mod tests {
         }
     }
 
+    #[allow(clippy::borrow_interior_mutable_const)]
+    #[allow(clippy::declare_interior_mutable_const)]
     mod misc {
         use super::*;
 
@@ -663,7 +665,7 @@ mod tests {
 
         use crate::tests::{setup, TestStore};
 
-        static STORE: LazyLock<TestStore> = LazyLock::new(|| TestStore::new());
+        static STORE: LazyLock<TestStore> = LazyLock::new(TestStore::new);
 
         const PROVIDER: LazyLock<Provider> = LazyLock::new(|| {
             create_provider_from_name("SoftwareProvider", STORE.impl_config().clone()).unwrap()
@@ -677,7 +679,7 @@ mod tests {
             let hash = PROVIDER.hash(&data, CryptoHash::Sha2_256)?;
             let hash2 = PROVIDER.hash(&data, CryptoHash::Sha2_256)?;
 
-            assert!(hash.len() > 0);
+            assert!(!hash.is_empty());
             assert_eq!(hash, hash2);
 
             Ok(())


### PR DESCRIPTION
### Added:

### Changed:

### Removed:

### Checklist:

-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
