### PR TITLE
fix: make DHKeyExchange::derive_* methods take self

### DIFF
--- a/flutter_app/integration_test/cal_test.dart
+++ b/flutter_app/integration_test/cal_test.dart
@@ -2,8 +2,8 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:cal_flutter_app/kvstore_service.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:cal_flutter_plugin/cal_flutter_plugin.dart' as cal;
+import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   await cal.RustLib.init();
@@ -38,7 +38,8 @@ void main() async {
             spec: cal.KeyPairSpec(
                 asymSpec: asymSpec,
                 signingHash: cal.CryptoHash.sha2256,
-                ephemeral: true));
+                ephemeral: true,
+                nonExportable: false));
         expect(handle, isNotNull);
         expect(store.count(), 1);
 

--- a/flutter_plugin/lib/src/rust/frb_generated.dart
+++ b/flutter_plugin/lib/src/rust/frb_generated.dart
@@ -431,7 +431,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
+        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
             that, serializer);
         sse_encode_list_prim_u_8_loose(serverPk, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
@@ -463,7 +463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
+        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
             that, serializer);
         sse_encode_list_prim_u_8_loose(serverPk, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
@@ -495,7 +495,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
+        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
             that, serializer);
         sse_encode_list_prim_u_8_loose(clientPk, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
@@ -527,7 +527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
+        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
             that, serializer);
         sse_encode_list_prim_u_8_loose(clientPk, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
@@ -2335,14 +2335,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  DhExchange
-      dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DhExchangeImpl.frbInternalDcoDecode(raw as List<dynamic>);
-  }
-
-  @protected
   Provider
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
           dynamic raw) {
@@ -3095,15 +3087,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return ProviderImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
-  }
-
-  @protected
-  DhExchange
-      sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return DhExchangeImpl.frbInternalSseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
@@ -3905,15 +3888,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
         (self as ProviderImpl).frbInternalSseEncode(move: true), serializer);
-  }
-
-  @protected
-  void
-      sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          DhExchange self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_usize(
-        (self as DhExchangeImpl).frbInternalSseEncode(move: false), serializer);
   }
 
   @protected

--- a/flutter_plugin/lib/src/rust/frb_generated.io.dart
+++ b/flutter_plugin/lib/src/rust/frb_generated.io.dart
@@ -108,11 +108,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           dynamic raw);
 
   @protected
-  DhExchange
-      dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          dynamic raw);
-
-  @protected
   Provider
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
           dynamic raw);
@@ -430,11 +425,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           SseDeserializer deserializer);
 
   @protected
-  DhExchange
-      sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          SseDeserializer deserializer);
-
-  @protected
   Provider
       sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
           SseDeserializer deserializer);
@@ -742,11 +732,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
       sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
           Provider self, SseSerializer serializer);
-
-  @protected
-  void
-      sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          DhExchange self, SseSerializer serializer);
 
   @protected
   void

--- a/flutter_plugin/lib/src/rust/frb_generated.web.dart
+++ b/flutter_plugin/lib/src/rust/frb_generated.web.dart
@@ -110,11 +110,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           dynamic raw);
 
   @protected
-  DhExchange
-      dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          dynamic raw);
-
-  @protected
   Provider
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
           dynamic raw);
@@ -432,11 +427,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           SseDeserializer deserializer);
 
   @protected
-  DhExchange
-      sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          SseDeserializer deserializer);
-
-  @protected
   Provider
       sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
           SseDeserializer deserializer);
@@ -744,11 +734,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
       sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
           Provider self, SseSerializer serializer);
-
-  @protected
-  void
-      sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDHExchange(
-          DhExchange self, SseSerializer serializer);
 
   @protected
   void

--- a/flutter_plugin/rust/src/frb_generated.rs
+++ b/flutter_plugin/rust/src/frb_generated.rs
@@ -176,29 +176,13 @@ fn wire__crypto_layer__common__DhExchange_derive_client_key_handles_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DHExchange>,
-            >>::sse_decode(&mut deserializer);
+            let api_that = <DHExchange>::sse_decode(&mut deserializer);
             let api_server_pk = <Vec<u8>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, CalError>((move || {
-                    let mut api_that_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_that, 0, true,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let mut api_that_guard = api_that_guard.unwrap();
                     let output_ok = crypto_layer::common::DHExchange::derive_client_key_handles(
-                        &mut *api_that_guard,
+                        api_that,
                         &api_server_pk,
                     )?;
                     Ok(output_ok)
@@ -229,29 +213,13 @@ fn wire__crypto_layer__common__DhExchange_derive_client_session_keys_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DHExchange>,
-            >>::sse_decode(&mut deserializer);
+            let api_that = <DHExchange>::sse_decode(&mut deserializer);
             let api_server_pk = <Vec<u8>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, CalError>((move || {
-                    let mut api_that_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_that, 0, true,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let mut api_that_guard = api_that_guard.unwrap();
                     let output_ok = crypto_layer::common::DHExchange::derive_client_session_keys(
-                        &mut *api_that_guard,
+                        api_that,
                         &api_server_pk,
                     )?;
                     Ok(output_ok)
@@ -282,29 +250,13 @@ fn wire__crypto_layer__common__DhExchange_derive_server_key_handles_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DHExchange>,
-            >>::sse_decode(&mut deserializer);
+            let api_that = <DHExchange>::sse_decode(&mut deserializer);
             let api_client_pk = <Vec<u8>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, CalError>((move || {
-                    let mut api_that_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_that, 0, true,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let mut api_that_guard = api_that_guard.unwrap();
                     let output_ok = crypto_layer::common::DHExchange::derive_server_key_handles(
-                        &mut *api_that_guard,
+                        api_that,
                         &api_client_pk,
                     )?;
                     Ok(output_ok)
@@ -335,29 +287,13 @@ fn wire__crypto_layer__common__DhExchange_derive_server_session_keys_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DHExchange>,
-            >>::sse_decode(&mut deserializer);
+            let api_that = <DHExchange>::sse_decode(&mut deserializer);
             let api_client_pk = <Vec<u8>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, CalError>((move || {
-                    let mut api_that_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_that, 0, true,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let mut api_that_guard = api_that_guard.unwrap();
                     let output_ok = crypto_layer::common::DHExchange::derive_server_session_keys(
-                        &mut *api_that_guard,
+                        api_that,
                         &api_client_pk,
                     )?;
                     Ok(output_ok)

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -63,6 +63,19 @@ macro_rules! delegate_enum {
             }
         )+
     };
+    ($(pub fn $method:ident(self $(,$arg:ident: $type:ty)* $(,)?) $(-> $ret:ty)?;)+) => {
+        $(
+            pub fn $method(self $(,$arg: $type)*) $(-> $ret)? {
+                match self.implementation.$method($($arg),*) {
+                    Ok(v) => Ok(v),
+                    Err(e) => {
+                        error!("Error in {}: {}", stringify!($method), e);
+                        Err(e)
+                    }
+                }
+            }
+        )+
+    };
 }
 
 macro_rules! delegate_enum_bare {
@@ -305,28 +318,28 @@ impl DHExchange {
 
     delegate_enum! {
         pub fn derive_client_session_keys(
-            &mut self,
+            self,
             server_pk: &[u8],
         ) -> Result<(Vec<u8>, Vec<u8>), CalError>;
     }
 
     delegate_enum! {
         pub fn derive_server_session_keys(
-            &mut self,
+            self,
             client_pk: &[u8],
         ) -> Result<(Vec<u8>, Vec<u8>), CalError>;
     }
 
     delegate_enum! {
         pub fn derive_client_key_handles(
-            &mut self,
+            self,
             server_pk: &[u8],
         ) -> Result<(KeyHandle, KeyHandle), CalError>;
     }
 
     delegate_enum! {
         pub fn derive_server_key_handles(
-            &mut self,
+            self,
             client_pk: &[u8],
         ) -> Result<(KeyHandle, KeyHandle), CalError>;
     }

--- a/src/common/traits/key_handle.rs
+++ b/src/common/traits/key_handle.rs
@@ -173,24 +173,18 @@ pub(crate) trait DHKeyExchangeImpl: Send + Sync {
     fn get_public_key(&self) -> Result<Vec<u8>, CalError>;
 
     /// Derive client session keys (rx, tx) - client is the templator in your code
-    fn derive_client_session_keys(
-        &mut self,
-        server_pk: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>), CalError>;
+    fn derive_client_session_keys(self, server_pk: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError>;
 
     /// Derive server session keys (rx, tx) - server is the requestor in your code
-    fn derive_server_session_keys(
-        &mut self,
-        client_pk: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>), CalError>;
+    fn derive_server_session_keys(self, client_pk: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError>;
 
     fn derive_client_key_handles(
-        &mut self,
+        self,
         server_pk: &[u8],
     ) -> Result<(KeyHandle, KeyHandle), CalError>;
 
     fn derive_server_key_handles(
-        &mut self,
+        self,
         client_pk: &[u8],
     ) -> Result<(KeyHandle, KeyHandle), CalError>;
 }

--- a/src/stub/mod.rs
+++ b/src/stub/mod.rs
@@ -214,30 +214,24 @@ impl DHKeyExchangeImpl for StubDHKeyExchange {
     }
 
     #[doc = " Derive client session keys (rx, tx) - client is the templator in your code"]
-    fn derive_client_session_keys(
-        &mut self,
-        server_pk: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>), CalError> {
+    fn derive_client_session_keys(self, server_pk: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError> {
         todo!()
     }
 
     #[doc = " Derive server session keys (rx, tx) - server is the requestor in your code"]
-    fn derive_server_session_keys(
-        &mut self,
-        client_pk: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>), CalError> {
+    fn derive_server_session_keys(self, client_pk: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError> {
         todo!()
     }
 
     fn derive_client_key_handles(
-        &mut self,
+        self,
         server_pk: &[u8],
     ) -> Result<(KeyHandle, KeyHandle), CalError> {
         todo!()
     }
 
     fn derive_server_key_handles(
-        &mut self,
+        self,
         client_pk: &[u8],
     ) -> Result<(KeyHandle, KeyHandle), CalError> {
         todo!()

--- a/src/tests/software/provider_tests.rs
+++ b/src/tests/software/provider_tests.rs
@@ -55,7 +55,7 @@ mod tests {
 
             for key_pair_spec in key_pair_spec_list {
                 // Client creates an instance of SoftwareDHExchange
-                let mut client_exchange = SoftwareDHExchange::new(
+                let client_exchange = SoftwareDHExchange::new(
                     "key_id_client".to_string(),
                     storage_manager.clone(),
                     key_pair_spec,
@@ -63,7 +63,7 @@ mod tests {
                 .unwrap();
 
                 // Server creates an instance of SoftwareDHExchange
-                let mut server_exchange = SoftwareDHExchange::new(
+                let server_exchange = SoftwareDHExchange::new(
                     "key_id_server".to_string(),
                     storage_manager.clone(),
                     key_pair_spec,
@@ -156,7 +156,7 @@ mod tests {
 
             for key_pair_spec in key_pair_spec_list {
                 // Client creates an instance of SoftwareDHExchange
-                let mut client_exchange = SoftwareDHExchange::new(
+                let client_exchange = SoftwareDHExchange::new(
                     "key_id_client".to_string(),
                     storage_manager.clone(),
                     key_pair_spec,
@@ -164,7 +164,7 @@ mod tests {
                 .unwrap();
 
                 // Server creates an instance of SoftwareDHExchange
-                let mut server_exchange = SoftwareDHExchange::new(
+                let server_exchange = SoftwareDHExchange::new(
                     "key_id_server".to_string(),
                     storage_manager.clone(),
                     key_pair_spec,
@@ -301,7 +301,7 @@ mod tests {
             );
 
             // Client creates an instance of SoftwareDHExchange
-            let mut client_exchange = SoftwareDHExchange::new(
+            let client_exchange = SoftwareDHExchange::new(
                 "key_id_client".to_string(),
                 storage_manager,
                 KeyPairSpec::default(),
@@ -337,12 +337,14 @@ mod tests {
             );
 
             // Client creates an instance of SoftwareDHExchange
-            let mut client_exchange = SoftwareDHExchange::new(
+            let client_exchange = SoftwareDHExchange::new(
                 "key_id_client".to_string(),
                 storage_manager.clone(),
                 KeyPairSpec::default(),
             )
             .unwrap();
+
+            let client_exchange2 = client_exchange.clone();
 
             // Generate two different server public keys
             let server_exchange1 = SoftwareDHExchange::new(
@@ -367,7 +369,7 @@ mod tests {
                 .expect("Failed to derive client session keys with first server");
 
             // Client derives keys with second server - this should work fine with your implementation
-            let (rx2, tx2) = client_exchange
+            let (rx2, tx2) = client_exchange2
                 .derive_client_session_keys(&server_public_key2)
                 .expect("Failed to derive client session keys with second server");
 
@@ -387,7 +389,7 @@ mod tests {
             );
 
             // Client1 creates an instance of SoftwareDHExchange
-            let mut client1_exchange = SoftwareDHExchange::new(
+            let client1_exchange = SoftwareDHExchange::new(
                 "key_id_client1".to_string(),
                 storage_manager.clone(),
                 KeyPairSpec::default(),
@@ -395,7 +397,7 @@ mod tests {
             .unwrap();
 
             // Client2 creates an instance of SoftwareDHExchange
-            let mut client2_exchange = SoftwareDHExchange::new(
+            let client2_exchange = SoftwareDHExchange::new(
                 "key_id_client2".to_string(),
                 storage_manager.clone(),
                 KeyPairSpec::default(),
@@ -403,13 +405,13 @@ mod tests {
             .unwrap();
 
             // Server instances for each client
-            let mut server_for_client1 = SoftwareDHExchange::new(
+            let server_for_client1 = SoftwareDHExchange::new(
                 "key_id_server_for_client1".to_string(),
                 storage_manager.clone(),
                 KeyPairSpec::default(),
             )
             .unwrap();
-            let mut server_for_client2 = SoftwareDHExchange::new(
+            let server_for_client2 = SoftwareDHExchange::new(
                 "key_id_server_for_client2".to_string(),
                 storage_manager.clone(),
                 KeyPairSpec::default(),

--- a/ts-types/package-lock.json
+++ b/ts-types/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nmshd/rs-crypto-types",
-			"version": "0.5.2",
+			"version": "0.5.3",
 			"license": "MIT",
 			"dependencies": {
 				"typia": "^8.0.3"


### PR DESCRIPTION
### Added:

### Changed:
DHKeyExchange::derive_* methods take self instead of &mut self, deriving further keys can be done with either derive_key_from_base or by cloning DHKeyExchange.
### Removed:

### Checklist:

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [x] Are changes in common propagated to all providers that are currently in use?
    -   [x] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [x] Does the flutter plugin still compile?
-   [x] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [x] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
