### PR TITLE
fix: add missing KDF::argon2i option

### DIFF
--- a/flutter_plugin/lib/src/rust/frb_generated.dart
+++ b/flutter_plugin/lib/src/rust/frb_generated.dart
@@ -2723,6 +2723,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return KDF_Argon2id(
           dco_decode_box_autoadd_argon_2_options(raw[1]),
         );
+      case 2:
+        return KDF_Argon2i(
+          dco_decode_box_autoadd_argon_2_options(raw[1]),
+        );
       default:
         throw Exception("unreachable");
     }
@@ -3470,6 +3474,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 1:
         var var_field0 = sse_decode_box_autoadd_argon_2_options(deserializer);
         return KDF_Argon2id(var_field0);
+      case 2:
+        var var_field0 = sse_decode_box_autoadd_argon_2_options(deserializer);
+        return KDF_Argon2i(var_field0);
       default:
         throw UnimplementedError('');
     }
@@ -4306,6 +4313,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_argon_2_options(field0, serializer);
       case KDF_Argon2id(field0: final field0):
         sse_encode_i_32(1, serializer);
+        sse_encode_box_autoadd_argon_2_options(field0, serializer);
+      case KDF_Argon2i(field0: final field0):
+        sse_encode_i_32(2, serializer);
         sse_encode_box_autoadd_argon_2_options(field0, serializer);
     }
   }

--- a/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/crypto/algorithms/key_derivation.dart
+++ b/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/crypto/algorithms/key_derivation.dart
@@ -57,6 +57,9 @@ sealed class KDF with _$KDF {
   const factory KDF.argon2Id(
     Argon2Options field0,
   ) = KDF_Argon2id;
+  const factory KDF.argon2I(
+    Argon2Options field0,
+  ) = KDF_Argon2i;
 
   static Future<KDF> default_() => RustLib.instance.api
       .cryptoLayerCommonCryptoAlgorithmsKeyDerivationKdfDefault();

--- a/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/crypto/algorithms/key_derivation.freezed.dart
+++ b/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/crypto/algorithms/key_derivation.freezed.dart
@@ -21,18 +21,21 @@ mixin _$KDF {
   TResult when<TResult extends Object?>({
     required TResult Function(Argon2Options field0) argon2D,
     required TResult Function(Argon2Options field0) argon2Id,
+    required TResult Function(Argon2Options field0) argon2I,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(Argon2Options field0)? argon2D,
     TResult? Function(Argon2Options field0)? argon2Id,
+    TResult? Function(Argon2Options field0)? argon2I,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(Argon2Options field0)? argon2D,
     TResult Function(Argon2Options field0)? argon2Id,
+    TResult Function(Argon2Options field0)? argon2I,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -40,18 +43,21 @@ mixin _$KDF {
   TResult map<TResult extends Object?>({
     required TResult Function(KDF_Argon2d value) argon2D,
     required TResult Function(KDF_Argon2id value) argon2Id,
+    required TResult Function(KDF_Argon2i value) argon2I,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(KDF_Argon2d value)? argon2D,
     TResult? Function(KDF_Argon2id value)? argon2Id,
+    TResult? Function(KDF_Argon2i value)? argon2I,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(KDF_Argon2d value)? argon2D,
     TResult Function(KDF_Argon2id value)? argon2Id,
+    TResult Function(KDF_Argon2i value)? argon2I,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -166,6 +172,7 @@ class _$KDF_Argon2dImpl extends KDF_Argon2d {
   TResult when<TResult extends Object?>({
     required TResult Function(Argon2Options field0) argon2D,
     required TResult Function(Argon2Options field0) argon2Id,
+    required TResult Function(Argon2Options field0) argon2I,
   }) {
     return argon2D(field0);
   }
@@ -175,6 +182,7 @@ class _$KDF_Argon2dImpl extends KDF_Argon2d {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(Argon2Options field0)? argon2D,
     TResult? Function(Argon2Options field0)? argon2Id,
+    TResult? Function(Argon2Options field0)? argon2I,
   }) {
     return argon2D?.call(field0);
   }
@@ -184,6 +192,7 @@ class _$KDF_Argon2dImpl extends KDF_Argon2d {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(Argon2Options field0)? argon2D,
     TResult Function(Argon2Options field0)? argon2Id,
+    TResult Function(Argon2Options field0)? argon2I,
     required TResult orElse(),
   }) {
     if (argon2D != null) {
@@ -197,6 +206,7 @@ class _$KDF_Argon2dImpl extends KDF_Argon2d {
   TResult map<TResult extends Object?>({
     required TResult Function(KDF_Argon2d value) argon2D,
     required TResult Function(KDF_Argon2id value) argon2Id,
+    required TResult Function(KDF_Argon2i value) argon2I,
   }) {
     return argon2D(this);
   }
@@ -206,6 +216,7 @@ class _$KDF_Argon2dImpl extends KDF_Argon2d {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(KDF_Argon2d value)? argon2D,
     TResult? Function(KDF_Argon2id value)? argon2Id,
+    TResult? Function(KDF_Argon2i value)? argon2I,
   }) {
     return argon2D?.call(this);
   }
@@ -215,6 +226,7 @@ class _$KDF_Argon2dImpl extends KDF_Argon2d {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(KDF_Argon2d value)? argon2D,
     TResult Function(KDF_Argon2id value)? argon2Id,
+    TResult Function(KDF_Argon2i value)? argon2I,
     required TResult orElse(),
   }) {
     if (argon2D != null) {
@@ -310,6 +322,7 @@ class _$KDF_Argon2idImpl extends KDF_Argon2id {
   TResult when<TResult extends Object?>({
     required TResult Function(Argon2Options field0) argon2D,
     required TResult Function(Argon2Options field0) argon2Id,
+    required TResult Function(Argon2Options field0) argon2I,
   }) {
     return argon2Id(field0);
   }
@@ -319,6 +332,7 @@ class _$KDF_Argon2idImpl extends KDF_Argon2id {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(Argon2Options field0)? argon2D,
     TResult? Function(Argon2Options field0)? argon2Id,
+    TResult? Function(Argon2Options field0)? argon2I,
   }) {
     return argon2Id?.call(field0);
   }
@@ -328,6 +342,7 @@ class _$KDF_Argon2idImpl extends KDF_Argon2id {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(Argon2Options field0)? argon2D,
     TResult Function(Argon2Options field0)? argon2Id,
+    TResult Function(Argon2Options field0)? argon2I,
     required TResult orElse(),
   }) {
     if (argon2Id != null) {
@@ -341,6 +356,7 @@ class _$KDF_Argon2idImpl extends KDF_Argon2id {
   TResult map<TResult extends Object?>({
     required TResult Function(KDF_Argon2d value) argon2D,
     required TResult Function(KDF_Argon2id value) argon2Id,
+    required TResult Function(KDF_Argon2i value) argon2I,
   }) {
     return argon2Id(this);
   }
@@ -350,6 +366,7 @@ class _$KDF_Argon2idImpl extends KDF_Argon2id {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(KDF_Argon2d value)? argon2D,
     TResult? Function(KDF_Argon2id value)? argon2Id,
+    TResult? Function(KDF_Argon2i value)? argon2I,
   }) {
     return argon2Id?.call(this);
   }
@@ -359,6 +376,7 @@ class _$KDF_Argon2idImpl extends KDF_Argon2id {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(KDF_Argon2d value)? argon2D,
     TResult Function(KDF_Argon2id value)? argon2Id,
+    TResult Function(KDF_Argon2i value)? argon2I,
     required TResult orElse(),
   }) {
     if (argon2Id != null) {
@@ -380,5 +398,155 @@ abstract class KDF_Argon2id extends KDF {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KDF_Argon2idImplCopyWith<_$KDF_Argon2idImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$KDF_Argon2iImplCopyWith<$Res> implements $KDFCopyWith<$Res> {
+  factory _$$KDF_Argon2iImplCopyWith(
+          _$KDF_Argon2iImpl value, $Res Function(_$KDF_Argon2iImpl) then) =
+      __$$KDF_Argon2iImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Argon2Options field0});
+}
+
+/// @nodoc
+class __$$KDF_Argon2iImplCopyWithImpl<$Res>
+    extends _$KDFCopyWithImpl<$Res, _$KDF_Argon2iImpl>
+    implements _$$KDF_Argon2iImplCopyWith<$Res> {
+  __$$KDF_Argon2iImplCopyWithImpl(
+      _$KDF_Argon2iImpl _value, $Res Function(_$KDF_Argon2iImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of KDF
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(_$KDF_Argon2iImpl(
+      null == field0
+          ? _value.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as Argon2Options,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$KDF_Argon2iImpl extends KDF_Argon2i {
+  const _$KDF_Argon2iImpl(this.field0) : super._();
+
+  @override
+  final Argon2Options field0;
+
+  @override
+  String toString() {
+    return 'KDF.argon2I(field0: $field0)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$KDF_Argon2iImpl &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  /// Create a copy of KDF
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$KDF_Argon2iImplCopyWith<_$KDF_Argon2iImpl> get copyWith =>
+      __$$KDF_Argon2iImplCopyWithImpl<_$KDF_Argon2iImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(Argon2Options field0) argon2D,
+    required TResult Function(Argon2Options field0) argon2Id,
+    required TResult Function(Argon2Options field0) argon2I,
+  }) {
+    return argon2I(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(Argon2Options field0)? argon2D,
+    TResult? Function(Argon2Options field0)? argon2Id,
+    TResult? Function(Argon2Options field0)? argon2I,
+  }) {
+    return argon2I?.call(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(Argon2Options field0)? argon2D,
+    TResult Function(Argon2Options field0)? argon2Id,
+    TResult Function(Argon2Options field0)? argon2I,
+    required TResult orElse(),
+  }) {
+    if (argon2I != null) {
+      return argon2I(field0);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(KDF_Argon2d value) argon2D,
+    required TResult Function(KDF_Argon2id value) argon2Id,
+    required TResult Function(KDF_Argon2i value) argon2I,
+  }) {
+    return argon2I(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(KDF_Argon2d value)? argon2D,
+    TResult? Function(KDF_Argon2id value)? argon2Id,
+    TResult? Function(KDF_Argon2i value)? argon2I,
+  }) {
+    return argon2I?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(KDF_Argon2d value)? argon2D,
+    TResult Function(KDF_Argon2id value)? argon2Id,
+    TResult Function(KDF_Argon2i value)? argon2I,
+    required TResult orElse(),
+  }) {
+    if (argon2I != null) {
+      return argon2I(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class KDF_Argon2i extends KDF {
+  const factory KDF_Argon2i(final Argon2Options field0) = _$KDF_Argon2iImpl;
+  const KDF_Argon2i._() : super._();
+
+  @override
+  Argon2Options get field0;
+
+  /// Create a copy of KDF
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$KDF_Argon2iImplCopyWith<_$KDF_Argon2iImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/flutter_plugin/rust/src/frb_generated.rs
+++ b/flutter_plugin/rust/src/frb_generated.rs
@@ -2783,6 +2783,9 @@ const _: fn() = || {
         crypto_layer::common::crypto::algorithms::key_derivation::KDF::Argon2id(field0) => {
             let _: crypto_layer::common::crypto::algorithms::key_derivation::Argon2Options = field0;
         }
+        crypto_layer::common::crypto::algorithms::key_derivation::KDF::Argon2i(field0) => {
+            let _: crypto_layer::common::crypto::algorithms::key_derivation::Argon2Options = field0;
+        }
     }
     {
         let KeyPairSpec = None::<crypto_layer::common::config::KeyPairSpec>.unwrap();
@@ -3511,6 +3514,12 @@ impl SseDecode for crypto_layer::common::crypto::algorithms::key_derivation::KDF
             1 => {
                 let mut var_field0 = <crypto_layer::common::crypto::algorithms::key_derivation::Argon2Options>::sse_decode(deserializer);
                 return crypto_layer::common::crypto::algorithms::key_derivation::KDF::Argon2id(
+                    var_field0,
+                );
+            }
+            2 => {
+                let mut var_field0 = <crypto_layer::common::crypto::algorithms::key_derivation::Argon2Options>::sse_decode(deserializer);
+                return crypto_layer::common::crypto::algorithms::key_derivation::KDF::Argon2i(
                     var_field0,
                 );
             }
@@ -4495,6 +4504,9 @@ impl flutter_rust_bridge::IntoDart
             crypto_layer::common::crypto::algorithms::key_derivation::KDF::Argon2id(field0) => {
                 [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
+            crypto_layer::common::crypto::algorithms::key_derivation::KDF::Argon2i(field0) => {
+                [2.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
             _ => {
                 unimplemented!("");
             }
@@ -5304,6 +5316,10 @@ impl SseEncode for crypto_layer::common::crypto::algorithms::key_derivation::KDF
             }
             crypto_layer::common::crypto::algorithms::key_derivation::KDF::Argon2id(field0) => {
                 <i32>::sse_encode(1, serializer);
+                <crypto_layer::common::crypto::algorithms::key_derivation::Argon2Options>::sse_encode(field0, serializer);
+            }
+            crypto_layer::common::crypto::algorithms::key_derivation::KDF::Argon2i(field0) => {
+                <i32>::sse_encode(2, serializer);
                 <crypto_layer::common::crypto::algorithms::key_derivation::Argon2Options>::sse_encode(field0, serializer);
             }
             _ => {

--- a/src/common/crypto/algorithms/key_derivation.rs
+++ b/src/common/crypto/algorithms/key_derivation.rs
@@ -33,6 +33,7 @@ pub enum KDF {
     Argon2d(Argon2Options),
     /// Partial brute force and partial side channel resistance.
     Argon2id(Argon2Options),
+    Argon2i(Argon2Options),
 }
 
 /// flutter_rust_bridge:non_opaque

--- a/src/software/provider.rs
+++ b/src/software/provider.rs
@@ -478,6 +478,7 @@ impl ProviderImpl for SoftwareProvider {
         kdf: KDF,
     ) -> Result<KeyHandle, CalError> {
         let (argo2_algorithm, argon2_option) = match kdf {
+            KDF::Argon2i(o) => (argon2::Algorithm::Argon2i, o),
             KDF::Argon2d(o) => (argon2::Algorithm::Argon2d, o),
             KDF::Argon2id(o) => (argon2::Algorithm::Argon2id, o),
             // _ => return Err(CalError::not_implemented()),

--- a/ts-types/generated/KDF.ts
+++ b/ts-types/generated/KDF.ts
@@ -29,4 +29,7 @@ import type { Argon2Options } from "./Argon2Options";
  * ```
  * flutter_rust_bridge:non_opaque
  */
-export type KDF = { "Argon2d": Argon2Options } | { "Argon2id": Argon2Options };
+export type KDF =
+  | { "Argon2d": Argon2Options }
+  | { "Argon2id": Argon2Options }
+  | { "Argon2i": Argon2Options };


### PR DESCRIPTION
### Added:

### Changed:

### Removed:

### Checklist:

-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
