### PR TITLE
Fix/xchacha20 fix for sw provider

### DIFF
--- a/src/software/mod.rs
+++ b/src/software/mod.rs
@@ -106,7 +106,7 @@ impl From<Cipher> for &'static aead::Algorithm {
             Cipher::AesGcm128 => &ring::aead::AES_128_GCM,
             Cipher::AesGcm256 => &ring::aead::AES_256_GCM,
             Cipher::ChaCha20Poly1305 => &ring::aead::CHACHA20_POLY1305,
-            _ => panic!("Unsupported cipher"), // Handle other cases or return an error
+            _ => panic!("Unsupported cipher: {:?}", cipher), // Handle other cases or return an error
         }
     }
 }

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"description": "Crypto Layer TS type definitions.",
 	"homepage": "https://enmeshed.eu",
 	"repository": "github:nmshd/rust-crypto",


### PR DESCRIPTION
### Added:

### Changed:

### Removed:

### Checklist:

-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
