### PR TITLE
Changed: Added Deprecations to all non ephemeral DH Exchange Methods

### DIFF
--- a/.github/workflows/unit-test-pr.yml
+++ b/.github/workflows/unit-test-pr.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        # with:
+        #   save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Unit Test Rust Code
         run: cargo test -F software
 

--- a/.github/workflows/unit-test-pr.yml
+++ b/.github/workflows/unit-test-pr.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     branches:
       - main
   push:
@@ -15,19 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      - uses: arduino/setup-task@v2
       - name: Unit Test Rust Code
-        run: task test-cal
+        run: cargo test -F software
 
   test-pr-ts-types:
     name: Test TS-Types
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # node-version: 23
+          cache: 'npm'
       - uses: arduino/setup-task@v2
       - name: Test TS Types
         run: task prerequisites-ts test-ts-types

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -153,14 +153,16 @@ impl Provider {
         ) -> Result<DHExchange, CalError>;
     }
 
-    #[deprecated(note = "Use start_dh_exchange of KeyPairHandle instead.")]
-    delegate_enum! {
-        pub fn dh_exchange_from_keys(
-            &mut self,
-            public_key: &[u8],
-            private_key: &[u8],
-            spec: KeyPairSpec,
-        ) -> Result<DHExchange, CalError>;
+    #[deprecated(note = "Non ephemeral dh exchanges are possibly insecure.")]
+    #[allow(dead_code)]
+    fn dh_exchange_from_keys(
+        &mut self,
+        public_key: &[u8],
+        private_key: &[u8],
+        spec: KeyPairSpec,
+    ) -> Result<DHExchange, CalError> {
+        self.implementation
+            .dh_exchange_from_keys(public_key, private_key, spec)
     }
 
     delegate_enum! {
@@ -241,8 +243,10 @@ impl KeyPairHandle {
         pub fn extract_key(&self) -> Result<Vec<u8>, CalError>;
     }
 
-    delegate_enum! {
-        pub fn start_dh_exchange(&self) -> Result<DHExchange, CalError>;
+    #[deprecated(note = "Non ephemeral dh exchanges are possibly insecure.")]
+    #[allow(dead_code)]
+    fn start_dh_exchange(&self) -> Result<DHExchange, CalError> {
+        self.implementation.start_dh_exchange()
     }
 
     delegate_enum! {

--- a/src/common/traits/key_handle.rs
+++ b/src/common/traits/key_handle.rs
@@ -128,7 +128,7 @@ pub(crate) trait KeyPairHandleImpl: Send + Sync {
     /// with [CalErrorKind::NotImplemented](super::CalErrorKind::NotImplemented).
     fn extract_key(&self) -> Result<Vec<u8>, CalError>;
 
-    /// Starts a [DHExchange].
+    /// [DEPRECATED]: Starts a [DHExchange].
     ///
     /// Some Providers might return [CalError]
     /// with [CalErrorKind::NotImplemented](super::CalErrorKind::NotImplemented).
@@ -173,10 +173,16 @@ pub(crate) trait DHKeyExchangeImpl: Send + Sync {
     fn get_public_key(&self) -> Result<Vec<u8>, CalError>;
 
     /// Derive client session keys (rx, tx) - client is the templator in your code
-    fn derive_client_session_keys(&mut self, server_pk: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError>;
+    fn derive_client_session_keys(
+        &mut self,
+        server_pk: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>), CalError>;
 
     /// Derive server session keys (rx, tx) - server is the requestor in your code
-    fn derive_server_session_keys(&mut self, client_pk: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError>;
+    fn derive_server_session_keys(
+        &mut self,
+        client_pk: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>), CalError>;
 
     fn derive_client_key_handles(
         &mut self,

--- a/src/common/traits/module_provider.rs
+++ b/src/common/traits/module_provider.rs
@@ -132,7 +132,6 @@ pub(crate) trait ProviderImpl: Send + Sync {
     /// [DEPRECATED]: Starts a dh exchange from a raw private key and it's public key.
     ///
     /// `start_dh_exchange` of `KeyPairHandle` is preferable for use with crypto layer.
-    #[deprecated(note = "Use start_dh_exchange of KeyPairHandle instead.")]
     #[allow(dead_code, unused_variables)]
     fn dh_exchange_from_keys(
         &mut self,

--- a/ts-types/manual/KeyPairHandle.ts
+++ b/ts-types/manual/KeyPairHandle.ts
@@ -14,5 +14,6 @@ export type KeyPairHandle = {
 	id: () => Promise<string>;
 	delete: () => Promise<void>;
 	spec: () => Promise<KeyPairSpec>;
+	/** @deprecated Non ephemeral dh exchange might be insecure. */
 	startDhExchange: () => Promise<DHExchange>;
 };

--- a/ts-types/manual/Provider.ts
+++ b/ts-types/manual/Provider.ts
@@ -23,7 +23,7 @@ export type Provider = {
 		publicKey: Uint8Array,
 	) => Promise<KeyPairHandle>;
 	startEphemeralDhExchange: (spec: KeyPairSpec) => Promise<DHExchange>;
-	/** @deprecated Use {@link KeyPairHandle.startDhExchange} instead. */
+	/** @deprecated Non ephemeral dh exchange might be insecure. */
 	dhExchangeFromKeys: (
 		publicKey: Uint8Array,
 		privateKey: Uint8Array,

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Crypto Layer TS type definitions.",
 	"homepage": "https://enmeshed.eu",
 	"repository": "github:nmshd/rust-crypto",


### PR DESCRIPTION
### Fixed:
* Fixed deprecation message in `dh_exchaneg_from_keys` not being shown.

### Changed:
* Marked `start_dh_exchange` in `KeyPairHandle` as deprecated.
* Minor speed improvement for ci.

### Checklist:

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
