### PR TITLE
Feature: Derive Key Method for Software Provider Key Handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "color-eyre",
  "core-foundation 0.10.0",
  "der",
+ "digest",
  "ed25519-compact",
  "ed25519-dalek",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 ed25519-compact = { version = "2.1.1", optional = true }
 sled = "0.34.7"
 hmac = "0.12.1"
+digest = "0.10.7"
 
 [dev-dependencies]
 color-eyre = "0.6.3"

--- a/src/common/crypto/algorithms/encryption.rs
+++ b/src/common/crypto/algorithms/encryption.rs
@@ -96,3 +96,16 @@ pub enum Cipher {
     ChaCha20Poly1305,
     XChaCha20Poly1305,
 }
+
+impl Cipher {
+    /// Returns the key size in bytes.
+    pub(crate) fn len(&self) -> u32 {
+        match self {
+            Self::AesCbc128 | Self::AesGcm128 => 16,
+            Self::AesCbc256
+            | Self::AesGcm256
+            | Self::ChaCha20Poly1305
+            | Self::XChaCha20Poly1305 => 32,
+        }
+    }
+}

--- a/src/common/crypto/algorithms/encryption.rs
+++ b/src/common/crypto/algorithms/encryption.rs
@@ -99,7 +99,7 @@ pub enum Cipher {
 
 impl Cipher {
     /// Returns the key size in bytes.
-    pub(crate) fn len(&self) -> u32 {
+    pub(crate) fn len(&self) -> usize {
         match self {
             Self::AesCbc128 | Self::AesGcm128 => 16,
             Self::AesCbc256

--- a/src/common/traits/key_handle.rs
+++ b/src/common/traits/key_handle.rs
@@ -53,7 +53,7 @@ pub(crate) trait KeyHandleImpl: Send + Sync {
 
     fn verify_hmac(&self, data: &[u8], hmac: &[u8]) -> Result<bool, CalError>;
 
-    /// Derives a key from this key as base.
+    /// Derives a key from this key as base with the same spec as the base key.
     ///
     /// This operation is deterministic, meaning the same nonce and key are always going to result in the same [KeyHandle].
     fn derive_key(&self, nonce: &[u8]) -> Result<KeyHandle, CalError>;


### PR DESCRIPTION
- **feat: add method to cipher config for getting expected key length**
- **docs: added what spec a derived key should have**
- **feat: implemented derive key for key handle for software provider**
- **tests: test new derive key method of software key handle**

### Added:
- Derive key method for software key handle.
- Added docs regarding what spec a derived key has.

### Changed:

### Removed:

### Checklist:

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
