### PR TITLE
Refactor: Explicit Encryption With or Without IV Methods, Generics for Error Generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "x25519-dalek",
  "x509-cert",
  "yubikey",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ ed25519-compact = { version = "2.1.1", optional = true }
 sled = "0.34.7"
 hmac = "0.12.1"
 digest = "0.10.7"
+zeroize = "1.8.1"
 
 [dev-dependencies]
 color-eyre = "0.6.3"

--- a/cSpell.json
+++ b/cSpell.json
@@ -32,6 +32,7 @@
         "thiserror",
         "typia",
         "yubi",
-        "yubikey"
+        "yubikey",
+        "Zeroize"
     ]
 }

--- a/flutter_plugin/lib/src/rust/frb_generated.dart
+++ b/flutter_plugin/lib/src/rust/frb_generated.dart
@@ -77,7 +77,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => 1404532017;
+  int get rustContentHash => 1296864754;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -125,7 +125,15 @@ abstract class RustLibApi extends BaseApi {
   Future<KeyHandle> cryptoLayerCommonKeyHandleDeriveKey(
       {required KeyHandle that, required List<int> nonce});
 
+  Future<(Uint8List, Uint8List)> cryptoLayerCommonKeyHandleEncrypt(
+      {required KeyHandle that, required List<int> data});
+
   Future<(Uint8List, Uint8List)> cryptoLayerCommonKeyHandleEncryptData(
+      {required KeyHandle that,
+      required List<int> data,
+      required List<int> iv});
+
+  Future<Uint8List> cryptoLayerCommonKeyHandleEncryptWithIv(
       {required KeyHandle that,
       required List<int> data,
       required List<int> iv});
@@ -704,6 +712,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<(Uint8List, Uint8List)> cryptoLayerCommonKeyHandleEncrypt(
+      {required KeyHandle that, required List<int> data}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyHandle(
+            that, serializer);
+        sse_encode_list_prim_u_8_loose(data, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 12, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData:
+            sse_decode_record_list_prim_u_8_strict_list_prim_u_8_strict,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCalError,
+      ),
+      constMeta: kCryptoLayerCommonKeyHandleEncryptConstMeta,
+      argValues: [that, data],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCryptoLayerCommonKeyHandleEncryptConstMeta =>
+      const TaskConstMeta(
+        debugName: "KeyHandle_encrypt",
+        argNames: ["that", "data"],
+      );
+
+  @override
   Future<(Uint8List, Uint8List)> cryptoLayerCommonKeyHandleEncryptData(
       {required KeyHandle that,
       required List<int> data,
@@ -716,7 +754,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_list_prim_u_8_loose(data, serializer);
         sse_encode_list_prim_u_8_loose(iv, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 12, port: port_);
+            funcId: 13, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -737,6 +775,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<Uint8List> cryptoLayerCommonKeyHandleEncryptWithIv(
+      {required KeyHandle that,
+      required List<int> data,
+      required List<int> iv}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyHandle(
+            that, serializer);
+        sse_encode_list_prim_u_8_loose(data, serializer);
+        sse_encode_list_prim_u_8_loose(iv, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 14, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_list_prim_u_8_strict,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCalError,
+      ),
+      constMeta: kCryptoLayerCommonKeyHandleEncryptWithIvConstMeta,
+      argValues: [that, data, iv],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCryptoLayerCommonKeyHandleEncryptWithIvConstMeta =>
+      const TaskConstMeta(
+        debugName: "KeyHandle_encrypt_with_iv",
+        argNames: ["that", "data", "iv"],
+      );
+
+  @override
   Future<Uint8List> cryptoLayerCommonKeyHandleExtractKey(
       {required KeyHandle that}) {
     return handler.executeNormal(NormalTask(
@@ -745,7 +815,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 13, port: port_);
+            funcId: 15, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -774,7 +844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_list_prim_u_8_loose(data, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 14, port: port_);
+            funcId: 16, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -801,7 +871,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 15, port: port_);
+            funcId: 17, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -828,7 +898,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 16, port: port_);
+            funcId: 18, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_key_spec,
@@ -859,7 +929,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_list_prim_u_8_loose(data, serializer);
         sse_encode_list_prim_u_8_loose(hmac, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 17, port: port_);
+            funcId: 19, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -888,7 +958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_list_prim_u_8_loose(data, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 18, port: port_);
+            funcId: 20, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -916,7 +986,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyPairHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 19, port: port_);
+            funcId: 21, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -948,7 +1018,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_list_prim_u_8_loose(data, serializer);
         sse_encode_list_prim_u_8_loose(iv, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 20, port: port_);
+            funcId: 22, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -976,7 +1046,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyPairHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 21, port: port_);
+            funcId: 23, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1004,7 +1074,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyPairHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 22, port: port_);
+            funcId: 24, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1032,7 +1102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyPairHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 23, port: port_);
+            funcId: 25, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -1061,7 +1131,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_list_prim_u_8_loose(data, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 24, port: port_);
+            funcId: 26, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1089,7 +1159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyPairHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 25, port: port_);
+            funcId: 27, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_key_pair_spec,
@@ -1116,7 +1186,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerKeyPairHandle(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 26, port: port_);
+            funcId: 28, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1149,7 +1219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_list_prim_u_8_loose(data, serializer);
         sse_encode_list_prim_u_8_loose(signature, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 27, port: port_);
+            funcId: 29, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -1178,7 +1248,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_box_autoadd_key_spec(spec, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 28, port: port_);
+            funcId: 30, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1208,7 +1278,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_box_autoadd_key_pair_spec(spec, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 29, port: port_);
+            funcId: 31, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1245,7 +1315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(context, serializer);
         sse_encode_box_autoadd_key_spec(spec, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 30, port: port_);
+            funcId: 32, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1282,7 +1352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_key_spec(algorithm, serializer);
         sse_encode_box_autoadd_kdf(kdf, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 31, port: port_);
+            funcId: 33, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1317,7 +1387,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_list_prim_u_8_loose(privateKey, serializer);
         sse_encode_box_autoadd_key_pair_spec(spec, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 32, port: port_);
+            funcId: 34, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1346,7 +1416,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 33, port: port_);
+            funcId: 35, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_record_string_spec,
@@ -1374,7 +1444,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 34, port: port_);
+            funcId: 36, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_provider_config,
@@ -1402,7 +1472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_usize(len, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 35, port: port_);
+            funcId: 37, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1433,7 +1503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_list_prim_u_8_loose(input, serializer);
         sse_encode_crypto_hash(hash, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 36, port: port_);
+            funcId: 38, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1465,7 +1535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_key_spec(spec, serializer);
         sse_encode_list_prim_u_8_loose(data, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 37, port: port_);
+            funcId: 39, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1500,7 +1570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_list_prim_u_8_loose(publicKey, serializer);
         sse_encode_list_prim_u_8_loose(privateKey, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 38, port: port_);
+            funcId: 40, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1533,7 +1603,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_key_pair_spec(spec, serializer);
         sse_encode_list_prim_u_8_loose(publicKey, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 39, port: port_);
+            funcId: 41, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1563,7 +1633,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_String(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 40, port: port_);
+            funcId: 42, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1593,7 +1663,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_String(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 41, port: port_);
+            funcId: 43, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1622,7 +1692,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerProvider(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 42, port: port_);
+            funcId: 44, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -1650,7 +1720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_box_autoadd_key_pair_spec(spec, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 43, port: port_);
+            funcId: 45, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1678,7 +1748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 45, port: port_);
+            funcId: 47, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_argon_2_options,
@@ -1705,7 +1775,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 46, port: port_);
+            funcId: 48, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_asymmetric_key_spec,
@@ -1731,7 +1801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 47, port: port_);
+            funcId: 49, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_cipher,
@@ -1760,7 +1830,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_provider_config(conf, serializer);
         sse_encode_box_autoadd_provider_impl_config(implConf, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 48, port: port_);
+            funcId: 50, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1788,7 +1858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(name, serializer);
         sse_encode_box_autoadd_provider_impl_config(implConf, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 49, port: port_);
+            funcId: 51, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1814,7 +1884,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 50, port: port_);
+            funcId: 52, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_crypto_hash,
@@ -1840,7 +1910,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 51, port: port_);
+            funcId: 53, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -1876,7 +1946,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_DartFn_Inputs__Output_list_String_AnyhowException(
             allKeysFn, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 52, port: port_);
+            funcId: 54, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_provider_impl_config,
@@ -1903,7 +1973,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_provider_impl_config(implConfig, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 53, port: port_);
+            funcId: 55, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_record_string_provider_config,
@@ -1927,7 +1997,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 54, port: port_);
+            funcId: 56, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1950,7 +2020,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 55, port: port_);
+            funcId: 57, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_kdf,
@@ -1976,7 +2046,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 56, port: port_);
+            funcId: 58, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_key_pair_spec,
@@ -2000,7 +2070,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 57, port: port_);
+            funcId: 59, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_key_spec,
@@ -2026,7 +2096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_oid_type(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 58, port: port_);
+            funcId: 60, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2065,7 +2135,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             allKeysFn, serializer);
         sse_encode_list_additional_config(additionalConfig, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 59, port: port_);
+            funcId: 61, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_provider_impl_config,
@@ -4857,9 +4927,18 @@ class KeyHandleImpl extends RustOpaque implements KeyHandle {
       RustLib.instance.api
           .cryptoLayerCommonKeyHandleDeriveKey(that: this, nonce: nonce);
 
+  Future<(Uint8List, Uint8List)> encrypt({required List<int> data}) =>
+      RustLib.instance.api
+          .cryptoLayerCommonKeyHandleEncrypt(that: this, data: data);
+
   Future<(Uint8List, Uint8List)> encryptData(
           {required List<int> data, required List<int> iv}) =>
       RustLib.instance.api.cryptoLayerCommonKeyHandleEncryptData(
+          that: this, data: data, iv: iv);
+
+  Future<Uint8List> encryptWithIv(
+          {required List<int> data, required List<int> iv}) =>
+      RustLib.instance.api.cryptoLayerCommonKeyHandleEncryptWithIv(
           that: this, data: data, iv: iv);
 
   Future<Uint8List> extractKey() =>

--- a/flutter_plugin/lib/src/rust/third_party/crypto_layer/common.dart
+++ b/flutter_plugin/lib/src/rust/third_party/crypto_layer/common.dart
@@ -41,7 +41,12 @@ abstract class KeyHandle implements RustOpaqueInterface {
 
   Future<KeyHandle> deriveKey({required List<int> nonce});
 
+  Future<(Uint8List, Uint8List)> encrypt({required List<int> data});
+
   Future<(Uint8List, Uint8List)> encryptData(
+      {required List<int> data, required List<int> iv});
+
+  Future<Uint8List> encryptWithIv(
       {required List<int> data, required List<int> iv});
 
   Future<Uint8List> extractKey();

--- a/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/config.dart
+++ b/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/config.dart
@@ -13,7 +13,7 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'config.freezed.dart';
 
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `AdditionalConfigDiscriminants`, `SecurityLevelIter`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `cmp`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from_str`, `from_str`, `from`, `from`, `from`, `from`, `from`, `from`, `iter`, `len`, `next_back`, `next`, `nth`, `partial_cmp`, `size_hint`, `try_from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `cmp`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from_str`, `from_str`, `from`, `from`, `from`, `from`, `from`, `from`, `iter`, `len`, `next_back`, `next`, `nth`, `partial_cmp`, `size_hint`, `try_from`, `try_from`, `zeroize`
 
 @freezed
 sealed class AdditionalConfig with _$AdditionalConfig {

--- a/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/crypto/algorithms/encryption.dart
+++ b/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/crypto/algorithms/encryption.dart
@@ -6,7 +6,7 @@
 import '../../../../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `from_str`, `from_str`, `from`, `from`, `from`, `from`, `hash`, `hash`, `try_from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `from_str`, `from_str`, `from`, `from`, `from`, `from`, `hash`, `hash`, `try_from`, `try_from`, `zeroize`
 
 /// Represents the available encryption algorithms.
 ///

--- a/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/crypto/algorithms/hashes.dart
+++ b/flutter_plugin/lib/src/rust/third_party/crypto_layer/common/crypto/algorithms/hashes.dart
@@ -6,7 +6,7 @@
 import '../../../../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `eq`, `fmt`, `from_str`, `from`, `from`, `hash`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `eq`, `fmt`, `from_str`, `from`, `from`, `hash`, `try_from`, `zeroize`
 
 /// Represents the available hashing algorithms.
 ///

--- a/flutter_plugin/rust/Cargo.lock
+++ b/flutter_plugin/rust/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "chacha20",
  "core-foundation",
  "der",
+ "digest",
  "ed25519-compact",
  "enum_dispatch",
  "hmac",
@@ -651,6 +652,7 @@ dependencies = [
  "tracing-attributes",
  "tracing-subscriber",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]

--- a/flutter_plugin/rust/src/frb_generated.rs
+++ b/flutter_plugin/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1404532017;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1296864754;
 
 // Section: executor
 
@@ -604,6 +604,57 @@ fn wire__crypto_layer__common__KeyHandle_derive_key_impl(
         },
     )
 }
+fn wire__crypto_layer__common__KeyHandle_encrypt_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "KeyHandle_encrypt",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<KeyHandle>,
+            >>::sse_decode(&mut deserializer);
+            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, CalError>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok =
+                        crypto_layer::common::KeyHandle::encrypt(&*api_that_guard, &api_data)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crypto_layer__common__KeyHandle_encrypt_data_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -649,6 +700,61 @@ fn wire__crypto_layer__common__KeyHandle_encrypt_data_impl(
                     }
                     let api_that_guard = api_that_guard.unwrap();
                     let output_ok = crypto_layer::common::KeyHandle::encrypt_data(
+                        &*api_that_guard,
+                        &api_data,
+                        &api_iv,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crypto_layer__common__KeyHandle_encrypt_with_iv_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "KeyHandle_encrypt_with_iv",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<KeyHandle>,
+            >>::sse_decode(&mut deserializer);
+            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_iv = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, CalError>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = crypto_layer::common::KeyHandle::encrypt_with_iv(
                         &*api_that_guard,
                         &api_data,
                         &api_iv,
@@ -4100,53 +4206,55 @@ fn pde_ffi_dispatcher_primary_impl(
 9 => wire__crypto_layer__common__KeyHandle_decrypt_data_impl(port, ptr, rust_vec_len, data_len),
 10 => wire__crypto_layer__common__KeyHandle_delete_impl(port, ptr, rust_vec_len, data_len),
 11 => wire__crypto_layer__common__KeyHandle_derive_key_impl(port, ptr, rust_vec_len, data_len),
-12 => wire__crypto_layer__common__KeyHandle_encrypt_data_impl(port, ptr, rust_vec_len, data_len),
-13 => wire__crypto_layer__common__KeyHandle_extract_key_impl(port, ptr, rust_vec_len, data_len),
-14 => wire__crypto_layer__common__KeyHandle_hmac_impl(port, ptr, rust_vec_len, data_len),
-15 => wire__crypto_layer__common__KeyHandle_id_impl(port, ptr, rust_vec_len, data_len),
-16 => wire__crypto_layer__common__KeyHandle_spec_impl(port, ptr, rust_vec_len, data_len),
-17 => wire__crypto_layer__common__KeyHandle_verify_hmac_impl(port, ptr, rust_vec_len, data_len),
-18 => wire__crypto_layer__common__KeyPairHandle_decrypt_data_impl(port, ptr, rust_vec_len, data_len),
-19 => wire__crypto_layer__common__KeyPairHandle_delete_impl(port, ptr, rust_vec_len, data_len),
-20 => wire__crypto_layer__common__KeyPairHandle_encrypt_data_impl(port, ptr, rust_vec_len, data_len),
-21 => wire__crypto_layer__common__KeyPairHandle_extract_key_impl(port, ptr, rust_vec_len, data_len),
-22 => wire__crypto_layer__common__KeyPairHandle_get_public_key_impl(port, ptr, rust_vec_len, data_len),
-23 => wire__crypto_layer__common__KeyPairHandle_id_impl(port, ptr, rust_vec_len, data_len),
-24 => wire__crypto_layer__common__KeyPairHandle_sign_data_impl(port, ptr, rust_vec_len, data_len),
-25 => wire__crypto_layer__common__KeyPairHandle_spec_impl(port, ptr, rust_vec_len, data_len),
-26 => wire__crypto_layer__common__KeyPairHandle_start_dh_exchange_impl(port, ptr, rust_vec_len, data_len),
-27 => wire__crypto_layer__common__KeyPairHandle_verify_signature_impl(port, ptr, rust_vec_len, data_len),
-28 => wire__crypto_layer__common__Provider_create_key_impl(port, ptr, rust_vec_len, data_len),
-29 => wire__crypto_layer__common__Provider_create_key_pair_impl(port, ptr, rust_vec_len, data_len),
-30 => wire__crypto_layer__common__Provider_derive_key_from_base_impl(port, ptr, rust_vec_len, data_len),
-31 => wire__crypto_layer__common__Provider_derive_key_from_password_impl(port, ptr, rust_vec_len, data_len),
-32 => wire__crypto_layer__common__Provider_dh_exchange_from_keys_impl(port, ptr, rust_vec_len, data_len),
-33 => wire__crypto_layer__common__Provider_get_all_keys_impl(port, ptr, rust_vec_len, data_len),
-34 => wire__crypto_layer__common__Provider_get_capabilities_impl(port, ptr, rust_vec_len, data_len),
-35 => wire__crypto_layer__common__Provider_get_random_impl(port, ptr, rust_vec_len, data_len),
-36 => wire__crypto_layer__common__Provider_hash_impl(port, ptr, rust_vec_len, data_len),
-37 => wire__crypto_layer__common__Provider_import_key_impl(port, ptr, rust_vec_len, data_len),
-38 => wire__crypto_layer__common__Provider_import_key_pair_impl(port, ptr, rust_vec_len, data_len),
-39 => wire__crypto_layer__common__Provider_import_public_key_impl(port, ptr, rust_vec_len, data_len),
-40 => wire__crypto_layer__common__Provider_load_key_impl(port, ptr, rust_vec_len, data_len),
-41 => wire__crypto_layer__common__Provider_load_key_pair_impl(port, ptr, rust_vec_len, data_len),
-42 => wire__crypto_layer__common__Provider_provider_name_impl(port, ptr, rust_vec_len, data_len),
-43 => wire__crypto_layer__common__Provider_start_ephemeral_dh_exchange_impl(port, ptr, rust_vec_len, data_len),
-45 => wire__crypto_layer__common__crypto__algorithms__key_derivation__argon_2_options_default_impl(port, ptr, rust_vec_len, data_len),
-46 => wire__crypto_layer__common__crypto__algorithms__encryption__asymmetric_key_spec_default_impl(port, ptr, rust_vec_len, data_len),
-47 => wire__crypto_layer__common__crypto__algorithms__encryption__cipher_default_impl(port, ptr, rust_vec_len, data_len),
-48 => wire__crypto_layer__common__factory__create_provider_impl(port, ptr, rust_vec_len, data_len),
-49 => wire__crypto_layer__common__factory__create_provider_from_name_impl(port, ptr, rust_vec_len, data_len),
-50 => wire__crypto_layer__common__crypto__algorithms__hashes__crypto_hash_default_impl(port, ptr, rust_vec_len, data_len),
-51 => wire__crypto_layer__common__factory__get_all_providers_impl(port, ptr, rust_vec_len, data_len),
-52 => wire__crate__api__crypto__get_default_config_impl(port, ptr, rust_vec_len, data_len),
-53 => wire__crypto_layer__common__factory__get_provider_capabilities_impl(port, ptr, rust_vec_len, data_len),
-54 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crypto_layer__common__crypto__algorithms__key_derivation__kdf_default_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crypto_layer__common__config__key_pair_spec_default_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crypto_layer__common__config__key_spec_default_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crypto_layer__common__crypto__pkcs__standards__oid_type_as_str_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crypto_layer__common__config__provider_impl_config_new_impl(port, ptr, rust_vec_len, data_len),
+12 => wire__crypto_layer__common__KeyHandle_encrypt_impl(port, ptr, rust_vec_len, data_len),
+13 => wire__crypto_layer__common__KeyHandle_encrypt_data_impl(port, ptr, rust_vec_len, data_len),
+14 => wire__crypto_layer__common__KeyHandle_encrypt_with_iv_impl(port, ptr, rust_vec_len, data_len),
+15 => wire__crypto_layer__common__KeyHandle_extract_key_impl(port, ptr, rust_vec_len, data_len),
+16 => wire__crypto_layer__common__KeyHandle_hmac_impl(port, ptr, rust_vec_len, data_len),
+17 => wire__crypto_layer__common__KeyHandle_id_impl(port, ptr, rust_vec_len, data_len),
+18 => wire__crypto_layer__common__KeyHandle_spec_impl(port, ptr, rust_vec_len, data_len),
+19 => wire__crypto_layer__common__KeyHandle_verify_hmac_impl(port, ptr, rust_vec_len, data_len),
+20 => wire__crypto_layer__common__KeyPairHandle_decrypt_data_impl(port, ptr, rust_vec_len, data_len),
+21 => wire__crypto_layer__common__KeyPairHandle_delete_impl(port, ptr, rust_vec_len, data_len),
+22 => wire__crypto_layer__common__KeyPairHandle_encrypt_data_impl(port, ptr, rust_vec_len, data_len),
+23 => wire__crypto_layer__common__KeyPairHandle_extract_key_impl(port, ptr, rust_vec_len, data_len),
+24 => wire__crypto_layer__common__KeyPairHandle_get_public_key_impl(port, ptr, rust_vec_len, data_len),
+25 => wire__crypto_layer__common__KeyPairHandle_id_impl(port, ptr, rust_vec_len, data_len),
+26 => wire__crypto_layer__common__KeyPairHandle_sign_data_impl(port, ptr, rust_vec_len, data_len),
+27 => wire__crypto_layer__common__KeyPairHandle_spec_impl(port, ptr, rust_vec_len, data_len),
+28 => wire__crypto_layer__common__KeyPairHandle_start_dh_exchange_impl(port, ptr, rust_vec_len, data_len),
+29 => wire__crypto_layer__common__KeyPairHandle_verify_signature_impl(port, ptr, rust_vec_len, data_len),
+30 => wire__crypto_layer__common__Provider_create_key_impl(port, ptr, rust_vec_len, data_len),
+31 => wire__crypto_layer__common__Provider_create_key_pair_impl(port, ptr, rust_vec_len, data_len),
+32 => wire__crypto_layer__common__Provider_derive_key_from_base_impl(port, ptr, rust_vec_len, data_len),
+33 => wire__crypto_layer__common__Provider_derive_key_from_password_impl(port, ptr, rust_vec_len, data_len),
+34 => wire__crypto_layer__common__Provider_dh_exchange_from_keys_impl(port, ptr, rust_vec_len, data_len),
+35 => wire__crypto_layer__common__Provider_get_all_keys_impl(port, ptr, rust_vec_len, data_len),
+36 => wire__crypto_layer__common__Provider_get_capabilities_impl(port, ptr, rust_vec_len, data_len),
+37 => wire__crypto_layer__common__Provider_get_random_impl(port, ptr, rust_vec_len, data_len),
+38 => wire__crypto_layer__common__Provider_hash_impl(port, ptr, rust_vec_len, data_len),
+39 => wire__crypto_layer__common__Provider_import_key_impl(port, ptr, rust_vec_len, data_len),
+40 => wire__crypto_layer__common__Provider_import_key_pair_impl(port, ptr, rust_vec_len, data_len),
+41 => wire__crypto_layer__common__Provider_import_public_key_impl(port, ptr, rust_vec_len, data_len),
+42 => wire__crypto_layer__common__Provider_load_key_impl(port, ptr, rust_vec_len, data_len),
+43 => wire__crypto_layer__common__Provider_load_key_pair_impl(port, ptr, rust_vec_len, data_len),
+44 => wire__crypto_layer__common__Provider_provider_name_impl(port, ptr, rust_vec_len, data_len),
+45 => wire__crypto_layer__common__Provider_start_ephemeral_dh_exchange_impl(port, ptr, rust_vec_len, data_len),
+47 => wire__crypto_layer__common__crypto__algorithms__key_derivation__argon_2_options_default_impl(port, ptr, rust_vec_len, data_len),
+48 => wire__crypto_layer__common__crypto__algorithms__encryption__asymmetric_key_spec_default_impl(port, ptr, rust_vec_len, data_len),
+49 => wire__crypto_layer__common__crypto__algorithms__encryption__cipher_default_impl(port, ptr, rust_vec_len, data_len),
+50 => wire__crypto_layer__common__factory__create_provider_impl(port, ptr, rust_vec_len, data_len),
+51 => wire__crypto_layer__common__factory__create_provider_from_name_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crypto_layer__common__crypto__algorithms__hashes__crypto_hash_default_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crypto_layer__common__factory__get_all_providers_impl(port, ptr, rust_vec_len, data_len),
+54 => wire__crate__api__crypto__get_default_config_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crypto_layer__common__factory__get_provider_capabilities_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crypto_layer__common__crypto__algorithms__key_derivation__kdf_default_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crypto_layer__common__config__key_pair_spec_default_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crypto_layer__common__config__key_spec_default_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crypto_layer__common__crypto__pkcs__standards__oid_type_as_str_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crypto_layer__common__config__provider_impl_config_new_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -11,6 +11,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use strum::{EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
+use zeroize::Zeroize;
 
 use super::crypto::algorithms::{
     encryption::{AsymmetricKeySpec, Cipher},
@@ -86,7 +87,7 @@ pub enum Spec {
 }
 
 /// Struct used to configure keys.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, Zeroize)]
 #[cfg_attr(feature = "ts-interface", derive(ts_rs::TS), ts(export))]
 /// flutter_rust_bridge:non_opaque
 pub struct KeySpec {

--- a/src/common/crypto/algorithms/encryption.rs
+++ b/src/common/crypto/algorithms/encryption.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, PartialEq};
 use std::hash::Hash;
+use zeroize::Zeroize;
 
 use strum::{EnumString, IntoStaticStr};
 
@@ -85,6 +86,7 @@ pub enum AsymmetricKeySpec {
     Default,
     EnumString,
     IntoStaticStr,
+    Zeroize,
 )]
 #[cfg_attr(feature = "ts-interface", derive(ts_rs::TS), ts(export))]
 pub enum Cipher {

--- a/src/common/crypto/algorithms/hashes.rs
+++ b/src/common/crypto/algorithms/hashes.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use strum::{EnumString, IntoStaticStr};
+use zeroize::Zeroize;
 
 /// Represents the available hashing algorithms.
 ///
@@ -25,6 +26,7 @@ use strum::{EnumString, IntoStaticStr};
     Default,
     EnumString,
     IntoStaticStr,
+    Zeroize,
 )]
 #[cfg_attr(feature = "ts-interface", derive(ts_rs::TS), ts(export))]
 pub enum CryptoHash {

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -93,13 +93,13 @@ impl CalError {
     }
 
     pub(crate) fn bad_parameter(
-        description: String,
+        description: impl Into<String>,
         internal: bool,
         source: Option<anyhow::Error>,
     ) -> Self {
         Self {
             error_kind: CalErrorKind::BadParameter {
-                description,
+                description: description.into(),
                 internal,
             },
             source: source.unwrap_or_else(|| anyhow!("Bad Parameter Error")),
@@ -113,21 +113,24 @@ impl CalError {
         }
     }
 
-    pub(crate) fn missing_key(key_id: String, key_type: KeyType) -> Self {
+    pub(crate) fn missing_key(key_id: impl Into<String>, key_type: KeyType) -> Self {
         Self {
-            error_kind: CalErrorKind::MissingKey { key_id, key_type },
+            error_kind: CalErrorKind::MissingKey {
+                key_id: key_id.into(),
+                key_type,
+            },
             source: anyhow!("Missing Key Error"),
         }
     }
 
     pub(crate) fn missing_value(
-        description: String,
+        description: impl Into<String>,
         internal: bool,
         source: Option<anyhow::Error>,
     ) -> Self {
         Self {
             error_kind: CalErrorKind::MissingValue {
-                description,
+                description: description.into(),
                 internal,
             },
             source: source.unwrap_or_else(|| anyhow!("Missing Value Error")),
@@ -135,13 +138,13 @@ impl CalError {
     }
 
     pub(crate) fn failed_operation(
-        description: String,
+        description: impl Into<String>,
         internal: bool,
         source: Option<anyhow::Error>,
     ) -> Self {
         Self {
             error_kind: CalErrorKind::FailedOperation {
-                description,
+                description: description.into(),
                 internal,
             },
             source: source.unwrap_or_else(|| anyhow!("Failed Operation")),
@@ -149,30 +152,30 @@ impl CalError {
     }
 
     pub(crate) fn failed_init(
-        description: String,
+        description: impl Into<String>,
         internal: bool,
         source: Option<anyhow::Error>,
     ) -> Self {
         CalError {
             error_kind: CalErrorKind::InitializationError {
-                description,
+                description: description.into(),
                 internal,
             },
             source: source.unwrap_or_else(|| anyhow!("Initialization Error")),
         }
     }
 
-    pub(crate) fn unsupported_algorithm(algorithm: String) -> Self {
+    pub(crate) fn unsupported_algorithm(algorithm: impl Into<String>) -> Self {
         Self {
-            error_kind: CalErrorKind::UnsupportedAlgorithm(algorithm),
+            error_kind: CalErrorKind::UnsupportedAlgorithm(algorithm.into()),
             source: anyhow!("Unsupported Algorithm Error"),
         }
     }
 
-    pub(crate) fn initialization_error(description: String) -> Self {
+    pub(crate) fn initialization_error(description: impl Into<String>) -> Self {
         Self {
             error_kind: CalErrorKind::InitializationError {
-                description,
+                description: description.into(),
                 internal: true,
             },
             source: anyhow!("Initialization Error"),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -277,9 +277,22 @@ impl KeyHandle {
     delegate_enum! {
         pub fn extract_key(&self) -> Result<Vec<u8>, CalError>;
     }
-    delegate_enum! {
-        pub fn encrypt_data(&self, data: &[u8], iv: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError>;
+
+    #[deprecated(
+        note = "Deprecated in favor of the more specific `encrypt` and `encrypt_with_iv` methods."
+    )]
+    pub fn encrypt_data(&self, data: &[u8], iv: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError> {
+        self.implementation.encrypt_data(data, iv)
     }
+
+    delegate_enum! {
+        pub fn encrypt(&self, data: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError>;
+    }
+
+    delegate_enum! {
+        pub fn encrypt_with_iv(&self, data: &[u8], iv: &[u8]) -> Result<Vec<u8>, CalError>;
+    }
+
     delegate_enum! {
         pub fn decrypt_data(
             &self,

--- a/src/common/traits/key_handle.rs
+++ b/src/common/traits/key_handle.rs
@@ -37,7 +37,26 @@ pub(crate) trait KeyHandleImpl: Send + Sync {
     /// A `Result` containing the encrypted data and the used iv as a `Vec<u8>` on success,
     /// where the first value is the data and the second the iv,
     /// or a `CalError` on failure.
+    ///
+    /// If the iv argument is empty, a new iv is generated.
     fn encrypt_data(&self, data: &[u8], iv: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError>;
+
+    /// Encrypt data.
+    ///
+    /// The iv is randomly generated.
+    ///
+    /// The resulting output is a pair of cipher text and generated iv: `(cipher_text, iv)`
+    fn encrypt(&self, data: &[u8]) -> Result<(Vec<u8>, Vec<u8>), CalError> {
+        self.encrypt_data(data, &vec![])
+    }
+
+    /// Encrypt data with the given iv.
+    ///
+    /// Some providers panic, if the iv is not the correct length.
+    fn encrypt_with_iv(&self, data: &[u8], iv: &[u8]) -> Result<Vec<u8>, CalError> {
+        let (cipher_text, _) = self.encrypt_data(data, iv)?;
+        Ok(cipher_text)
+    }
 
     /// Decrypts the given encrypted data using the cryptographic key.
     ///

--- a/src/common/traits/key_handle.rs
+++ b/src/common/traits/key_handle.rs
@@ -53,7 +53,7 @@ pub(crate) trait KeyHandleImpl: Send + Sync {
 
     fn verify_hmac(&self, data: &[u8], hmac: &[u8]) -> Result<bool, CalError>;
 
-    /// Derives a key from this key as base with the same spec as the base key.
+    /// Derives an ephemeral key from this key as base with the same spec as the base key.
     ///
     /// This operation is deterministic, meaning the same nonce and key are always going to result in the same [KeyHandle].
     fn derive_key(&self, nonce: &[u8]) -> Result<KeyHandle, CalError>;

--- a/src/software/key_handle.rs
+++ b/src/software/key_handle.rs
@@ -277,7 +277,8 @@ impl KeyHandleImpl for SoftwareKeyHandle {
         use blake2::Blake2bVar;
         use digest::{Update, VariableOutput};
 
-        let spec = self.spec.clone();
+        let mut spec = self.spec.clone();
+        spec.ephemeral = true;
         let key_length = spec.cipher.len();
 
         let mut hasher = Blake2bVar::new(key_length).map_err(|e| {
@@ -310,14 +311,9 @@ impl KeyHandleImpl for SoftwareKeyHandle {
         let id = id_from_buffer(nonce)?;
 
         Ok(KeyHandle {
-            implementation: SoftwareKeyHandle::new(
-                id,
-                spec,
-                derived_key,
-                self.storage_manager.clone(),
-            )
-            .unwrap()
-            .into(),
+            implementation: SoftwareKeyHandle::new(id, spec, derived_key, None)
+                .unwrap()
+                .into(),
         })
     }
 

--- a/src/software/provider.rs
+++ b/src/software/provider.rs
@@ -543,7 +543,7 @@ impl ProviderImpl for SoftwareProvider {
         );
 
         let salt_str = SaltString::encode_b64(salt)
-            .map_err(|_| CalError::failed_operation("Failed to encode salt".into(), true, None))?;
+            .map_err(|_| CalError::failed_operation("Failed to encode salt", true, None))?;
 
         // Perform password hashing with specified parameters
         let password_hash = argon2

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::upper_case_acronyms)]
-use std::fmt;
+use std::{fmt, path::Path};
 
 use hmac::Mac;
 use serde::{Deserialize, Serialize};
@@ -112,7 +112,7 @@ fn extract_security_method(config: &[AdditionalConfig]) -> Result<ChecksumProvid
 
 impl StorageManager {
     pub(crate) fn new(
-        scope: String,
+        scope: impl Into<String>,
         config: &[AdditionalConfig],
     ) -> Result<Option<Self>, CalError> {
         let storage = extract_storage_method(config)?;
@@ -127,12 +127,12 @@ impl StorageManager {
                 checksum_provider,
                 key_handle: key_handle.map(Box::new),
                 storage,
-                scope,
+                scope: scope.into(),
             }
         }))
     }
 
-    pub(crate) fn store(&self, id: String, data: KeyData) -> Result<(), CalError> {
+    pub(crate) fn store(&self, id: impl AsRef<str>, data: KeyData) -> Result<(), CalError> {
         // encrypt secret data if KeyHandle is available
 
         let encrypted_data = KeyDataEncrypted {
@@ -184,15 +184,15 @@ impl StorageManager {
 
         // choose storage Strategy
         match self.storage {
-            Storage::KVStore(ref store) => store.store(self.scope.clone(), id.clone(), encoded),
-            Storage::FileStore(ref store) => store.store(self.scope.clone(), id.clone(), encoded),
+            Storage::KVStore(ref store) => store.store(self.scope.clone(), id.as_ref(), encoded),
+            Storage::FileStore(ref store) => store.store(self.scope.clone(), id.as_ref(), encoded),
         }
     }
 
-    pub(crate) fn get(&self, id: String) -> Result<KeyData, CalError> {
+    pub(crate) fn get(&self, id: impl AsRef<str>) -> Result<KeyData, CalError> {
         let value = match self.storage {
-            Storage::KVStore(ref store) => store.get(self.scope.clone(), id.clone()),
-            Storage::FileStore(ref store) => store.get(self.scope.clone(), id.clone()),
+            Storage::KVStore(ref store) => store.get(self.scope.clone(), id.as_ref()),
+            Storage::FileStore(ref store) => store.get(self.scope.clone(), id.as_ref()),
         }?;
 
         let decoded = serde_json::from_slice::<WithChecksum>(&value).map_err(|e| {
@@ -252,10 +252,10 @@ impl StorageManager {
         Ok(decrypted)
     }
 
-    pub(crate) fn delete(&self, id: String) {
+    pub(crate) fn delete(&self, id: impl AsRef<str>) {
         match self.storage {
-            Storage::KVStore(ref store) => store.delete(self.scope.clone(), id.clone()),
-            Storage::FileStore(ref store) => store.delete(self.scope.clone(), id.clone()),
+            Storage::KVStore(ref store) => store.delete(self.scope.clone(), id),
+            Storage::FileStore(ref store) => store.delete(self.scope.clone(), id),
         }
     }
 
@@ -301,8 +301,16 @@ impl fmt::Debug for KVStore {
 }
 
 impl KVStore {
-    fn store(&self, scope: String, key: String, value: Vec<u8>) -> Result<(), CalError> {
-        let valid = pollster::block_on((self.store_fn)(format!("{}:{}", scope, key), value));
+    fn store(
+        &self,
+        scope: impl AsRef<str>,
+        key: impl AsRef<str>,
+        value: Vec<u8>,
+    ) -> Result<(), CalError> {
+        let valid = pollster::block_on((self.store_fn)(
+            format!("{}:{}", scope.as_ref(), key.as_ref()),
+            value,
+        ));
         if valid {
             Ok(())
         } else {
@@ -314,16 +322,24 @@ impl KVStore {
         }
     }
 
-    fn get(&self, scope: String, key: String) -> Result<Vec<u8>, CalError> {
-        let value = pollster::block_on((self.get_fn)(format!("{}:{}", scope, key)));
+    fn get(&self, scope: impl AsRef<str>, key: impl AsRef<str>) -> Result<Vec<u8>, CalError> {
+        let value = pollster::block_on((self.get_fn)(format!(
+            "{}:{}",
+            scope.as_ref(),
+            key.as_ref()
+        )));
         match value {
             Some(data) => Ok(data),
-            None => Err(CalError::missing_key(key, KeyType::Private)),
+            None => Err(CalError::missing_key(key.as_ref(), KeyType::Private)),
         }
     }
 
-    fn delete(&self, scope: String, key: String) {
-        pollster::block_on((self.delete_fn)(format!("{}:{}", scope, key)));
+    fn delete(&self, scope: impl AsRef<str>, key: impl AsRef<str>) {
+        pollster::block_on((self.delete_fn)(format!(
+            "{}:{}",
+            scope.as_ref(),
+            key.as_ref()
+        )));
     }
 
     fn get_all_keys(&self, scope: String) -> Vec<Vec<u8>> {
@@ -337,8 +353,10 @@ impl KVStore {
     }
 }
 
-fn file_store_key_id(provider: &String, key: &String) -> Vec<u8> {
-    format!("{}:{}", provider, key).as_bytes().to_vec()
+fn file_store_key_id(provider: impl AsRef<str>, key: impl AsRef<str>) -> Vec<u8> {
+    format!("{}:{}", provider.as_ref(), key.as_ref())
+        .as_bytes()
+        .to_vec()
 }
 
 #[allow(dead_code)]
@@ -348,42 +366,47 @@ struct FileStore {
 }
 
 impl FileStore {
-    fn new(db_dir: String) -> Result<Self, CalError> {
+    fn new(db_dir: impl AsRef<Path>) -> Result<Self, CalError> {
         Ok(Self { db: open(db_dir)? })
     }
 
-    fn store(&self, provider: String, key: String, value: Vec<u8>) -> Result<(), CalError> {
-        let id = file_store_key_id(&provider, &key);
+    fn store(
+        &self,
+        provider: impl AsRef<str>,
+        key: impl AsRef<str>,
+        value: Vec<u8>,
+    ) -> Result<(), CalError> {
+        let id = file_store_key_id(provider, key);
         self.db.insert(id, value)?;
         Ok(())
     }
 
-    fn get(&self, provider: String, key: String) -> Result<Vec<u8>, CalError> {
-        let id = file_store_key_id(&provider, &key);
+    fn get(&self, provider: impl AsRef<str>, key: impl AsRef<str>) -> Result<Vec<u8>, CalError> {
+        let id = file_store_key_id(provider, key.as_ref());
         match self.db.get(id)? {
             Some(data) => Ok(data.as_ref().to_vec()),
             None => Err(CalError::missing_value(
-                format!("Sled (db): No data found for key: {}", key),
+                format!("Sled (db): No data found for key: {}", key.as_ref()),
                 true,
                 None,
             )),
         }
     }
 
-    fn delete(&self, provider: String, key: String) {
-        let id = file_store_key_id(&provider, &key);
+    fn delete(&self, provider: impl AsRef<str>, key: impl AsRef<str>) {
+        let id = file_store_key_id(provider, key.as_ref());
         match self.db.remove(id) {
             Ok(_) => {}
             Err(e) => {
                 // TODO: Change delete to return result?
-                tracing::error!(error = %e, "Storage Manager: Failed deletion of data for key {}", key)
+                tracing::error!(error = %e, "Storage Manager: Failed deletion of data for key {}", key.as_ref())
             }
         }
     }
 
-    fn get_all_keys(&self, scope: String) -> Vec<Vec<u8>> {
+    fn get_all_keys(&self, scope: impl AsRef<str>) -> Vec<Vec<u8>> {
         self.db
-            .scan_prefix(file_store_key_id(&scope, &"".into()))
+            .scan_prefix(file_store_key_id(scope, ""))
             .values()
             .filter(|result| match result {
                 Ok(_) => true,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -143,7 +143,7 @@ impl StorageManager {
                     self.key_handle
                         .as_ref()
                         .map(|key| {
-                            let (v, iv) = match key.encrypt_data(&secret, &[]) {
+                            let (v, iv) = match key.encrypt(&secret) {
                                 Ok(v) => v,
                                 Err(e) => return Err(e),
                             };

--- a/src/tests/software/key_handle_tests.rs
+++ b/src/tests/software/key_handle_tests.rs
@@ -280,7 +280,7 @@ mod tests {
 
             let plaintext = b"Test data for encryption and decryption via provider.";
 
-            let encrypted_data = software_key_handle.encrypt_data(plaintext, &[])?;
+            let encrypted_data = software_key_handle.encrypt(plaintext)?;
 
             assert_ne!(
                 encrypted_data.0, plaintext,
@@ -311,7 +311,7 @@ mod tests {
 
             let plaintext: &[u8] = &[];
 
-            let encrypted_data = software_key_handle.encrypt_data(plaintext, &[])?;
+            let encrypted_data = software_key_handle.encrypt(plaintext)?;
 
             let decrypted_data =
                 software_key_handle.decrypt_data(&encrypted_data.0, &encrypted_data.1)?;
@@ -338,7 +338,7 @@ mod tests {
 
             let plaintext = b"Data encrypted with key 1";
 
-            let encrypted_data = software_key_handle1.encrypt_data(plaintext, &[])?;
+            let encrypted_data = software_key_handle1.encrypt(plaintext)?;
 
             let decrypted_result =
                 software_key_handle2.decrypt_data(&encrypted_data.0, &encrypted_data.1);
@@ -363,7 +363,7 @@ mod tests {
 
             let plaintext = b"Data to encrypt and then tamper with.";
 
-            let mut encrypted_data = software_key_handle.encrypt_data(plaintext, &[])?;
+            let mut encrypted_data = software_key_handle.encrypt(plaintext)?;
 
             encrypted_data.0[15] ^= 0xFF;
 
@@ -407,7 +407,7 @@ mod tests {
 
             let plaintext = vec![0x61; 1_048_576]; // 1 MB of data
 
-            let encrypted_data = software_key_handle.encrypt_data(&plaintext, &[])?;
+            let encrypted_data = software_key_handle.encrypt(&plaintext)?;
 
             let decrypted_data =
                 software_key_handle.decrypt_data(&encrypted_data.0, &encrypted_data.1)?;
@@ -433,9 +433,9 @@ mod tests {
 
             let plaintext = b"Same plaintext encrypted multiple times";
 
-            let encrypted_data1 = software_key_handle.encrypt_data(plaintext, &[])?;
+            let encrypted_data1 = software_key_handle.encrypt(plaintext)?;
 
-            let encrypted_data2 = software_key_handle.encrypt_data(plaintext, &[])?;
+            let encrypted_data2 = software_key_handle.encrypt(plaintext)?;
 
             assert_ne!(
                 encrypted_data1, encrypted_data2,
@@ -528,7 +528,7 @@ mod tests {
 
             let plaintext = b"Testing encryption with different cipher specs";
 
-            let encrypted_data = software_key_handle256.encrypt_data(plaintext, &[])?;
+            let encrypted_data = software_key_handle256.encrypt(plaintext)?;
 
             let decrypted_result =
                 software_key_handle128.decrypt_data(&encrypted_data.0, &encrypted_data.1);
@@ -560,7 +560,7 @@ mod tests {
             for spec in specs {
                 let software_key_handle = create_software_key_handle(spec)?;
 
-                let encrypted_data = software_key_handle.encrypt_data(plaintext, &[])?;
+                let encrypted_data = software_key_handle.encrypt(plaintext)?;
 
                 let decrypted_data =
                     software_key_handle.decrypt_data(&encrypted_data.0, &encrypted_data.1)?;
@@ -604,12 +604,12 @@ mod tests {
                     let derived_key = key.derive_key(&derive_nonce)?;
 
                     id = derived_key.id()?;
-                    cipher_text = derived_key.encrypt_data(payload, &message_nonce)?;
+                    cipher_text = derived_key.encrypt_with_iv(payload, &message_nonce)?;
                 }
 
                 let derived_key = key.derive_key(&derive_nonce)?;
 
-                let received_message = derived_key.decrypt_data(&cipher_text.0, &message_nonce)?;
+                let received_message = derived_key.decrypt_data(&cipher_text, &message_nonce)?;
 
                 assert_eq!(received_message, payload);
                 assert_eq!(derived_key.id()?, id);

--- a/src/tests/software/provider_tests.rs
+++ b/src/tests/software/provider_tests.rs
@@ -215,7 +215,7 @@ mod tests {
                 let plaintext = b"Message from client to server";
 
                 // Client encrypts with their tx key
-                let (encrypted_data, iv) = client_tx_key_handle.encrypt_data(plaintext, &[])?;
+                let (encrypted_data, iv) = client_tx_key_handle.encrypt(plaintext)?;
 
                 // Server decrypts with their rx key
                 let decrypted_data = server_rx_key_handle.decrypt_data(&encrypted_data, &iv)?;
@@ -260,8 +260,7 @@ mod tests {
                 let server_plaintext = b"Message from server to client";
 
                 // Server encrypts with their tx key
-                let (server_encrypted, iv) =
-                    server_tx_key_handle.encrypt_data(server_plaintext, &[])?;
+                let (server_encrypted, iv) = server_tx_key_handle.encrypt(server_plaintext)?;
 
                 // Client decrypts with their rx key
                 let client_decrypted = client_rx_key_handle.decrypt_data(&server_encrypted, &iv)?;

--- a/ts-types/manual/KeyHandle.ts
+++ b/ts-types/manual/KeyHandle.ts
@@ -2,7 +2,10 @@ import type { KeySpec } from "../generated/index.ts";
 
 export type KeyHandle = {
 	extractKey: () => Promise<Uint8Array>;
+	/** @deprecated In favor of the more explicit {@link KeyHandle.encrypt} and {@link KeyHandle.encryptWithIv} methods. */
 	encryptData: (data: Uint8Array, iv: Uint8Array) => Promise<[Uint8Array, Uint8Array]>;
+	encrypt: (data: Uint8Array) => Promise<[Uint8Array, Uint8Array]>;
+	encryptWithIv: (data: Uint8Array, iv: Uint8Array) => Promise<Uint8Array>;
 	decryptData: (
 		encryptedData: Uint8Array,
 		iv: Uint8Array,

--- a/ts-types/package-lock.json
+++ b/ts-types/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nmshd/rs-crypto-types",
-			"version": "0.8.0",
+			"version": "0.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"typia": "^8.0.3"

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Crypto Layer TS type definitions.",
 	"homepage": "https://enmeshed.eu",
 	"repository": "github:nmshd/rust-crypto",


### PR DESCRIPTION
### Added:
* Methods `encrypt` and `encrypt_with_iv` to replace `encrypt_data`.
	`encrypt_data` had the implicit behaviour of creating a new iv, if an empty iv was inputed.
	This was not documented.

### Changed:
* Creating erros does not involve manually converting descriptions into String.

### Removed:
* Deprecated `encrypt_data` of `KeyHandle`.

### Checklist:

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [x] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [x] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [x] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
