### PR TITLE
fix(SoftwareProvider): switch XChaCha20 to XChaCha20Poly1305

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +282,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +302,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -408,6 +432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -422,7 +447,7 @@ dependencies = [
  "bincode",
  "blake2",
  "blake2b_simd",
- "chacha20",
+ "chacha20poly1305",
  "color-eyre",
  "core-foundation 0.10.0",
  "der",
@@ -1728,6 +1753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2045,17 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -3370,6 +3412,16 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ ed25519-compact = { version = "2.1.1", optional = true }
 sled = "0.34.7"
 hmac = "0.12.1"
 digest = "0.10.7"
-zeroize = "1.8.1"
+zeroize = { version = "1.8.1", features = ["derive"] }
 
 [dev-dependencies]
 color-eyre = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ linux = ["tss-esapi"]
 apple-secure-enclave = ["dep:security-framework", "dep:core-foundation", "dep:base64"]
 win = ["dep:windows"]
 hsm = []
-software = ["dep:base64", "dep:blake2", "dep:blake2b_simd", "dep:ring", "dep:pkcs8", "dep:der", "dep:redb", "dep:ed25519-compact", "dep:chacha20", "dep:argon2", "dep:sha3", "dep:x25519-dalek", "dep:p256"]
+software = ["dep:base64", "dep:blake2", "dep:blake2b_simd", "dep:ring", "dep:pkcs8", "dep:der", "dep:redb", "dep:ed25519-compact", "dep:chacha20poly1305", "dep:argon2", "dep:sha3", "dep:x25519-dalek", "dep:p256"]
 software-keystore = ["software", "software-metadata"]
 software-metadata = ["software"]
 yubi = ["hsm", "dep:yubikey", "dep:x509-cert", "dep:base64", "dep:rsa", "dep:openssl"]
@@ -44,7 +44,7 @@ arrayref = { version = "0.3.7", optional = true }
 base64 = { version = "0.22.1", optional = true }
 blake2 = { version = "0.10.6", optional = true }
 blake2b_simd = { version = "1.0.3", optional = true }
-chacha20 = { version = "0.9.1", optional = true }
+chacha20poly1305 = { version = "0.10.1", optional = true }
 core-foundation = { version = "0.10.0", optional = true }
 der = { version = "0.7.9", optional = true }
 ed25519-dalek = { version = "2.1.1", optional = true }

--- a/flutter_plugin/rust/Cargo.lock
+++ b/flutter_plugin/rust/Cargo.lock
@@ -28,6 +28,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +413,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +447,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -611,6 +635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -624,7 +649,7 @@ dependencies = [
  "bincode",
  "blake2",
  "blake2b_simd",
- "chacha20",
+ "chacha20poly1305",
  "core-foundation",
  "der",
  "digest",
@@ -1695,6 +1720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "oslog"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +1861,17 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2672,6 +2714,16 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/src/common/crypto/algorithms/encryption.rs
+++ b/src/common/crypto/algorithms/encryption.rs
@@ -110,4 +110,15 @@ impl Cipher {
             | Self::XChaCha20Poly1305 => 32,
         }
     }
+
+    pub(crate) fn iv_len(&self) -> usize {
+        match self {
+            Self::AesCbc128
+            | Self::AesGcm128
+            | Self::AesCbc256
+            | Self::AesGcm256
+            | Self::ChaCha20Poly1305 => 12,
+            Self::XChaCha20Poly1305 => 24,
+        }
+    }
 }

--- a/src/software/key_handle.rs
+++ b/src/software/key_handle.rs
@@ -250,7 +250,7 @@ impl KeyHandleImpl for SoftwareKeyHandle {
                 let cipher = XChaCha20Poly1305::new(&key.into());
 
                 let result = cipher.decrypt(iv.into(), encrypted_data).map_err(|e| {
-                    CalError::failed_operation("failed encrypting", false, Some(anyhow!(e)))
+                    CalError::failed_operation("failed decrypting", false, Some(anyhow!(e)))
                 })?;
 
                 // No built-in authentication tag to remove, so the decrypted
@@ -406,7 +406,7 @@ impl KeyPairHandleImpl for SoftwareKeyPairHandle {
                 Ok(
                     UnparsedPublicKey::new(self.spec.asym_spec.into(), &self.public_key)
                         .verify(data, signature)
-                        .inspect_err(|e| error!("Failed to verify signature: {e:?}"))
+                        .inspect_err(|e| warn!("Failed to verify signature: {e:?}"))
                         .is_ok(),
                 )
             }

--- a/src/software/key_handle.rs
+++ b/src/software/key_handle.rs
@@ -385,7 +385,6 @@ impl KeyPairHandleImpl for SoftwareKeyPairHandle {
     }
 
     fn verify_signature(&self, data: &[u8], signature: &[u8]) -> Result<bool, CalError> {
-        warn!("Verifying signature");
         match self.spec.asym_spec {
             AsymmetricKeySpec::Curve25519 => {
                 ed25519_compact::PublicKey::from_slice(self.public_key.as_slice())
@@ -407,7 +406,7 @@ impl KeyPairHandleImpl for SoftwareKeyPairHandle {
                 Ok(
                     UnparsedPublicKey::new(self.spec.asym_spec.into(), &self.public_key)
                         .verify(data, signature)
-                        .inspect_err(|e| warn!("Failed to verify signature: {e:?}"))
+                        .inspect_err(|e| error!("Failed to verify signature: {e:?}"))
                         .is_ok(),
                 )
             }

--- a/src/tests/software/key_handle_tests.rs
+++ b/src/tests/software/key_handle_tests.rs
@@ -253,6 +253,7 @@ mod tests {
     }
     mod key_handle {
         use crate::tests::TestStore;
+        use test_case::test_case;
 
         use super::*;
 
@@ -267,12 +268,14 @@ mod tests {
             provider.create_key(spec)
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_encrypt_decrypt_data() -> Result<()> {
+        fn test_encrypt_decrypt_data(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm256,
+                cipher: cipher,
                 ..Default::default()
             };
 
@@ -298,12 +301,14 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_encrypt_decrypt_empty_data() -> Result<()> {
+        fn test_encrypt_decrypt_empty_data(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm128,
+                cipher: cipher,
                 ..Default::default()
             };
 
@@ -324,12 +329,14 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_decrypt_with_wrong_key() -> Result<()> {
+        fn test_decrypt_with_wrong_key(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm256,
+                cipher: cipher,
                 ..Default::default()
             };
 
@@ -350,12 +357,14 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_decrypt_modified_ciphertext() -> Result<()> {
+        fn test_decrypt_modified_ciphertext(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm256,
+                cipher: cipher,
                 ..Default::default()
             };
 
@@ -377,12 +386,14 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_id_method() -> Result<()> {
+        fn test_id_method(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm128,
+                cipher: cipher,
                 ..Default::default()
             };
 
@@ -394,12 +405,14 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_encrypt_decrypt_large_data() -> Result<()> {
+        fn test_encrypt_decrypt_large_data(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm256,
+                cipher: cipher,
                 ..Default::default()
             };
 
@@ -420,12 +433,14 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_encrypt_same_plaintext_multiple_times() -> Result<()> {
+        fn test_encrypt_same_plaintext_multiple_times(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm128,
+                cipher: cipher,
                 ..Default::default()
             };
 
@@ -461,19 +476,21 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_decrypt_random_data() -> Result<()> {
+        fn test_decrypt_random_data(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm256,
+                cipher: cipher,
                 ..Default::default()
             };
 
             let software_key_handle = create_software_key_handle(spec)?;
 
             let mut random_data = vec![0u8; 50];
-            let mut nonce = vec![0u8; 12];
+            let mut nonce = vec![0u8; spec.cipher.iv_len()];
             let rng = SystemRandom::new();
             rng.fill(&mut random_data).unwrap();
             rng.fill(&mut nonce).unwrap();
@@ -487,20 +504,23 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_decrypt_short_data() -> Result<()> {
+        fn test_decrypt_short_data(cipher: Cipher) -> Result<()> {
             setup();
             let spec = KeySpec {
-                cipher: Cipher::AesGcm256,
+                cipher: cipher,
                 ..Default::default()
             };
 
             let software_key_handle = create_software_key_handle(spec)?;
 
             let short_data = vec![0u8; 10];
+            let mut nonce = vec![0u8; spec.cipher.iv_len()];
 
-            let decrypted_result = software_key_handle.decrypt_data(&short_data, &[]);
+            let decrypted_result = software_key_handle.decrypt_data(&short_data, &nonce);
 
             assert!(
                 decrypted_result.is_err(),
@@ -540,80 +560,40 @@ mod tests {
             Ok(())
         }
 
-        #[test]
+        #[test_case(Cipher::AesGcm128)]
+        #[test_case(Cipher::AesGcm256)]
+        #[test_case(Cipher::XChaCha20Poly1305)]
         #[instrument]
-        fn test_encrypt_decrypt_multiple_keys() -> Result<()> {
-            setup();
-            let specs = vec![
-                KeySpec {
-                    cipher: Cipher::AesGcm128,
-                    ..Default::default()
-                },
-                KeySpec {
-                    cipher: Cipher::AesGcm256,
-                    ..Default::default()
-                },
-            ];
-
-            let plaintext = b"Testing multiple keys";
-
-            for spec in specs {
-                let software_key_handle = create_software_key_handle(spec)?;
-
-                let encrypted_data = software_key_handle.encrypt(plaintext)?;
-
-                let decrypted_data =
-                    software_key_handle.decrypt_data(&encrypted_data.0, &encrypted_data.1)?;
-
-                assert_eq!(
-                    from_utf8(&decrypted_data)?,
-                    from_utf8(plaintext)?,
-                    "Decrypted data does not match plaintext"
-                );
-            }
-            Ok(())
-        }
-
-        #[test]
-        #[instrument]
-        fn test_derive_key() -> Result<()> {
+        fn test_derive_key(cipher: Cipher) -> Result<()> {
             setup();
 
-            let specs = vec![
-                KeySpec {
-                    cipher: Cipher::AesGcm128,
-                    ..Default::default()
-                },
-                KeySpec {
-                    cipher: Cipher::AesGcm256,
-                    ..Default::default()
-                },
-            ];
+            let spec = KeySpec {
+                cipher: cipher,
+                ..Default::default()
+            };
 
-            for spec in specs {
-                let key = create_software_key_handle(spec)?;
+            let key = create_software_key_handle(spec)?;
 
-                let derive_nonce = [1, 2, 3, 4, 5, 6, 7, 8];
-                let message_nonce: Vec<u8> = (0..12).collect();
+            let derive_nonce = [1, 2, 3, 4, 5, 6, 7, 8];
+            let message_nonce: Vec<u8> = (0..(cipher.iv_len() as u8)).collect();
 
-                let payload = b"Hello World!";
-                let cipher_text;
-                let id;
+            let payload = b"Hello World!";
+            let cipher_text;
+            let id;
 
-                {
-                    let derived_key = key.derive_key(&derive_nonce)?;
-
-                    id = derived_key.id()?;
-                    cipher_text = derived_key.encrypt_with_iv(payload, &message_nonce)?;
-                }
-
+            {
                 let derived_key = key.derive_key(&derive_nonce)?;
 
-                let received_message = derived_key.decrypt_data(&cipher_text, &message_nonce)?;
-
-                assert_eq!(received_message, payload);
-                assert_eq!(derived_key.id()?, id);
+                id = derived_key.id()?;
+                cipher_text = derived_key.encrypt_with_iv(payload, &message_nonce)?;
             }
+
+            let derived_key = key.derive_key(&derive_nonce)?;
+
+            let received_message = derived_key.decrypt_data(&cipher_text, &message_nonce)?;
+
+            assert_eq!(received_message, payload);
+            assert_eq!(derived_key.id()?, id);
 
             Ok(())
         }


### PR DESCRIPTION
### Added:

### Changed:

### Removed:

### Checklist:

-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
