### PR TITLE
Feature: Non Exportable for KeySpec, Fix Wrong Iv For KeyPairHandle

### DIFF
--- a/.github/workflows/unit-test-pr.yml
+++ b/.github/workflows/unit-test-pr.yml
@@ -22,6 +22,17 @@ jobs:
         run: cargo check -F software,android
       - name: Unit Test Rust Code
         run: cargo test -F software
+    
+  test-pr-rs-apple:
+    name: Test Rust-Code (Apple)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        # with:
+        #   save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Check Rust Code
+        run: cargo check -F software,android,apple-secure-enclave
 
   test-pr-ts-types:
     name: Test TS-Types

--- a/.github/workflows/unit-test-pr.yml
+++ b/.github/workflows/unit-test-pr.yml
@@ -19,7 +19,7 @@ jobs:
         # with:
         #   save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Check Rust Code
-        run: cargo check -F software,android,apple-secure-enclave
+        run: cargo check -F software,android
       - name: Unit Test Rust Code
         run: cargo test -F software
 

--- a/.github/workflows/unit-test-pr.yml
+++ b/.github/workflows/unit-test-pr.yml
@@ -19,7 +19,7 @@ jobs:
         # with:
         #   save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Check Rust Code
-        run: cargo check -F software,android
+        run: cargo check -F software,android,apple-secure-enclave
       - name: Unit Test Rust Code
         run: cargo test -F software
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,7 @@ tasks:
     dir: ./cal_flutter_plugin/
     cmds:
       - flutter_rust_bridge_codegen generate --rust-preamble "use std::future::Future; use std::pin::Pin; use crypto_layer::common::config::DynFuture;"
+      - flutter pub run build_runner build
 
   test:
     desc: Execute non interactive tests.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,7 +62,7 @@ tasks:
   test-dart-bindings:
     desc: Test partially generated dart bindings.
     aliases: [testdt]
-    dir: ./flutter_plugin/rust/
+    dir: ./cal_flutter_plugin/rust/
     cmds:
       - cargo c
 

--- a/cal_flutter_plugin/example/pubspec.lock
+++ b/cal_flutter_plugin/example/pubspec.lock
@@ -119,6 +119,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -129,6 +137,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/cal_flutter_plugin/lib/src/rust/frb_generated.dart
+++ b/cal_flutter_plugin/lib/src/rust/frb_generated.dart
@@ -183,7 +183,6 @@ abstract class RustLibApi extends BaseApi {
   Future<Uint8List> cryptoLayerCommonKeyPairHandleEncryptData({
     required KeyPairHandle that,
     required List<int> data,
-    required List<int> iv,
   });
 
   Future<Uint8List> cryptoLayerCommonKeyPairHandleExtractKey({
@@ -1246,7 +1245,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<Uint8List> cryptoLayerCommonKeyPairHandleEncryptData({
     required KeyPairHandle that,
     required List<int> data,
-    required List<int> iv,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1257,7 +1255,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_list_prim_u_8_loose(data, serializer);
-          sse_encode_list_prim_u_8_loose(iv, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1271,7 +1268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCalError,
         ),
         constMeta: kCryptoLayerCommonKeyPairHandleEncryptDataConstMeta,
-        argValues: [that, data, iv],
+        argValues: [that, data],
         apiImpl: this,
       ),
     );
@@ -1280,7 +1277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCryptoLayerCommonKeyPairHandleEncryptDataConstMeta =>
       const TaskConstMeta(
         debugName: "KeyPairHandle_encrypt_data",
-        argNames: ["that", "data", "iv"],
+        argNames: ["that", "data"],
       );
 
   @override
@@ -3383,10 +3380,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           internal: dco_decode_bool(raw[2]),
         );
       case 6:
-        return CalErrorKind_UnsupportedAlgorithm(dco_decode_String(raw[1]));
+        return CalErrorKind_NonExportable();
       case 7:
-        return CalErrorKind_EphemeralKeyError();
+        return CalErrorKind_UnsupportedAlgorithm(dco_decode_String(raw[1]));
       case 8:
+        return CalErrorKind_EphemeralKeyError();
+      case 9:
         return CalErrorKind_Other();
       default:
         throw Exception("unreachable");
@@ -3451,12 +3450,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   KeySpec dco_decode_key_spec(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return KeySpec(
       cipher: dco_decode_cipher(arr[0]),
       signingHash: dco_decode_crypto_hash(arr[1]),
       ephemeral: dco_decode_bool(arr[2]),
+      nonExportable: dco_decode_bool(arr[3]),
     );
   }
 
@@ -4229,11 +4229,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           internal: var_internal,
         );
       case 6:
+        return CalErrorKind_NonExportable();
+      case 7:
         var var_field0 = sse_decode_String(deserializer);
         return CalErrorKind_UnsupportedAlgorithm(var_field0);
-      case 7:
-        return CalErrorKind_EphemeralKeyError();
       case 8:
+        return CalErrorKind_EphemeralKeyError();
+      case 9:
         return CalErrorKind_Other();
       default:
         throw UnimplementedError('');
@@ -4309,10 +4311,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_cipher = sse_decode_cipher(deserializer);
     var var_signingHash = sse_decode_crypto_hash(deserializer);
     var var_ephemeral = sse_decode_bool(deserializer);
+    var var_nonExportable = sse_decode_bool(deserializer);
     return KeySpec(
       cipher: var_cipher,
       signingHash: var_signingHash,
       ephemeral: var_ephemeral,
+      nonExportable: var_nonExportable,
     );
   }
 
@@ -5247,13 +5251,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(5, serializer);
         sse_encode_String(description, serializer);
         sse_encode_bool(internal, serializer);
-      case CalErrorKind_UnsupportedAlgorithm(field0: final field0):
+      case CalErrorKind_NonExportable():
         sse_encode_i_32(6, serializer);
+      case CalErrorKind_UnsupportedAlgorithm(field0: final field0):
+        sse_encode_i_32(7, serializer);
         sse_encode_String(field0, serializer);
       case CalErrorKind_EphemeralKeyError():
-        sse_encode_i_32(7, serializer);
-      case CalErrorKind_Other():
         sse_encode_i_32(8, serializer);
+      case CalErrorKind_Other():
+        sse_encode_i_32(9, serializer);
     }
   }
 
@@ -5313,6 +5319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_cipher(self.cipher, serializer);
     sse_encode_crypto_hash(self.signingHash, serializer);
     sse_encode_bool(self.ephemeral, serializer);
+    sse_encode_bool(self.nonExportable, serializer);
   }
 
   @protected
@@ -5911,14 +5918,10 @@ class KeyPairHandleImpl extends RustOpaque implements KeyPairHandle {
       RustLib.instance.api.cryptoLayerCommonKeyPairHandleDelete(that: this);
 
   /// Abstraction of asymmetric key pair handles.
-  Future<Uint8List> encryptData({
-    required List<int> data,
-    required List<int> iv,
-  }) => RustLib.instance.api.cryptoLayerCommonKeyPairHandleEncryptData(
-    that: this,
-    data: data,
-    iv: iv,
-  );
+  Future<Uint8List> encryptData({required List<int> data}) => RustLib
+      .instance
+      .api
+      .cryptoLayerCommonKeyPairHandleEncryptData(that: this, data: data);
 
   /// Abstraction of asymmetric key pair handles.
   Future<Uint8List> extractKey() =>

--- a/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common.dart
+++ b/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common.dart
@@ -79,10 +79,7 @@ abstract class KeyPairHandle implements RustOpaqueInterface {
   Future<void> delete();
 
   /// Abstraction of asymmetric key pair handles.
-  Future<Uint8List> encryptData({
-    required List<int> data,
-    required List<int> iv,
-  });
+  Future<Uint8List> encryptData({required List<int> data});
 
   /// Abstraction of asymmetric key pair handles.
   Future<Uint8List> extractKey();

--- a/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common/config.dart
+++ b/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common/config.dart
@@ -109,10 +109,14 @@ class KeySpec {
   /// If set to `true`, the key is going to be deleted when the handle is dropped.
   final bool ephemeral;
 
+  /// If set to `true`, the key cannot be exported.
+  final bool nonExportable;
+
   const KeySpec({
     required this.cipher,
     required this.signingHash,
     required this.ephemeral,
+    required this.nonExportable,
   });
 
   static Future<KeySpec> default_() =>
@@ -120,7 +124,10 @@ class KeySpec {
 
   @override
   int get hashCode =>
-      cipher.hashCode ^ signingHash.hashCode ^ ephemeral.hashCode;
+      cipher.hashCode ^
+      signingHash.hashCode ^
+      ephemeral.hashCode ^
+      nonExportable.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -129,7 +136,8 @@ class KeySpec {
           runtimeType == other.runtimeType &&
           cipher == other.cipher &&
           signingHash == other.signingHash &&
-          ephemeral == other.ephemeral;
+          ephemeral == other.ephemeral &&
+          nonExportable == other.nonExportable;
 }
 
 /// Capabilities of a Provider

--- a/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common/error.dart
+++ b/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common/error.dart
@@ -64,6 +64,7 @@ sealed class CalErrorKind with _$CalErrorKind {
     /// `true` if caused within this library. `false` if caused by another library.
     required bool internal,
   }) = CalErrorKind_InitializationError;
+  const factory CalErrorKind.nonExportable() = CalErrorKind_NonExportable;
 
   /// Algorithm requested is not supported by the provider.
   const factory CalErrorKind.unsupportedAlgorithm(String field0) =

--- a/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common/error.freezed.dart
+++ b/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common/error.freezed.dart
@@ -421,6 +421,38 @@ as bool,
 /// @nodoc
 
 
+class CalErrorKind_NonExportable extends CalErrorKind {
+  const CalErrorKind_NonExportable(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CalErrorKind_NonExportable);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CalErrorKind.nonExportable()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
 class CalErrorKind_UnsupportedAlgorithm extends CalErrorKind {
   const CalErrorKind_UnsupportedAlgorithm(this.field0): super._();
   

--- a/cal_flutter_plugin/rust/src/frb_generated.rs
+++ b/cal_flutter_plugin/rust/src/frb_generated.rs
@@ -1132,7 +1132,6 @@ fn wire__crypto_layer__common__KeyPairHandle_encrypt_data_impl(
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<KeyPairHandle>,
             >>::sse_decode(&mut deserializer);
             let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_iv = <Vec<u8>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, CalError>((move || {
@@ -1153,7 +1152,6 @@ fn wire__crypto_layer__common__KeyPairHandle_encrypt_data_impl(
                     let output_ok = crypto_layer::common::KeyPairHandle::encrypt_data(
                         &*api_that_guard,
                         &api_data,
-                        &api_iv,
                     )?;
                     Ok(output_ok)
                 })())
@@ -2997,6 +2995,7 @@ const _: fn() = || {
             let _: String = description;
             let _: bool = internal;
         }
+        crypto_layer::common::error::CalErrorKind::NonExportable => {}
         crypto_layer::common::error::CalErrorKind::UnsupportedAlgorithm(field0) => {
             let _: String = field0;
         }
@@ -3030,6 +3029,7 @@ const _: fn() = || {
         let _: crypto_layer::common::crypto::algorithms::encryption::Cipher = KeySpec.cipher;
         let _: crypto_layer::common::crypto::algorithms::hashes::CryptoHash = KeySpec.signing_hash;
         let _: bool = KeySpec.ephemeral;
+        let _: bool = KeySpec.non_exportable;
     }
     {
         let ProviderConfig = None::<crypto_layer::common::config::ProviderConfig>.unwrap();
@@ -3660,13 +3660,16 @@ impl SseDecode for crypto_layer::common::error::CalErrorKind {
                 };
             }
             6 => {
+                return crypto_layer::common::error::CalErrorKind::NonExportable;
+            }
+            7 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
                 return crypto_layer::common::error::CalErrorKind::UnsupportedAlgorithm(var_field0);
             }
-            7 => {
+            8 => {
                 return crypto_layer::common::error::CalErrorKind::EphemeralKeyError;
             }
-            8 => {
+            9 => {
                 return crypto_layer::common::error::CalErrorKind::Other;
             }
             _ => {
@@ -3796,10 +3799,12 @@ impl SseDecode for crypto_layer::common::config::KeySpec {
                 deserializer,
             );
         let mut var_ephemeral = <bool>::sse_decode(deserializer);
+        let mut var_nonExportable = <bool>::sse_decode(deserializer);
         return crypto_layer::common::config::KeySpec {
             cipher: var_cipher,
             signing_hash: var_signingHash,
             ephemeral: var_ephemeral,
+            non_exportable: var_nonExportable,
         };
     }
 }
@@ -4615,13 +4620,14 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<crypto_layer::common::error::C
                 internal.into_into_dart().into_dart(),
             ]
             .into_dart(),
+            crypto_layer::common::error::CalErrorKind::NonExportable => [6.into_dart()].into_dart(),
             crypto_layer::common::error::CalErrorKind::UnsupportedAlgorithm(field0) => {
-                [6.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+                [7.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
             crypto_layer::common::error::CalErrorKind::EphemeralKeyError => {
-                [7.into_dart()].into_dart()
+                [8.into_dart()].into_dart()
             }
-            crypto_layer::common::error::CalErrorKind::Other => [8.into_dart()].into_dart(),
+            crypto_layer::common::error::CalErrorKind::Other => [9.into_dart()].into_dart(),
             _ => {
                 unimplemented!("");
             }
@@ -4789,6 +4795,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<crypto_layer::common::config::
             self.0.cipher.into_into_dart().into_dart(),
             self.0.signing_hash.into_into_dart().into_dart(),
             self.0.ephemeral.into_into_dart().into_dart(),
+            self.0.non_exportable.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -5455,15 +5462,18 @@ impl SseEncode for crypto_layer::common::error::CalErrorKind {
                 <String>::sse_encode(description, serializer);
                 <bool>::sse_encode(internal, serializer);
             }
-            crypto_layer::common::error::CalErrorKind::UnsupportedAlgorithm(field0) => {
+            crypto_layer::common::error::CalErrorKind::NonExportable => {
                 <i32>::sse_encode(6, serializer);
+            }
+            crypto_layer::common::error::CalErrorKind::UnsupportedAlgorithm(field0) => {
+                <i32>::sse_encode(7, serializer);
                 <String>::sse_encode(field0, serializer);
             }
             crypto_layer::common::error::CalErrorKind::EphemeralKeyError => {
-                <i32>::sse_encode(7, serializer);
+                <i32>::sse_encode(8, serializer);
             }
             crypto_layer::common::error::CalErrorKind::Other => {
-                <i32>::sse_encode(8, serializer);
+                <i32>::sse_encode(9, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -5591,6 +5601,7 @@ impl SseEncode for crypto_layer::common::config::KeySpec {
             serializer,
         );
         <bool>::sse_encode(self.ephemeral, serializer);
+        <bool>::sse_encode(self.non_exportable, serializer);
     }
 }
 

--- a/flutter_app/.vscode/settings.json
+++ b/flutter_app/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.sourceDirectory": "M:/DEV/WorkProjects/nmshd2/rust-crypto/flutter_app/windows"
+}

--- a/flutter_app/lib/encryption_page.dart
+++ b/flutter_app/lib/encryption_page.dart
@@ -52,7 +52,8 @@ class _EncryptionPageState extends State<EncryptionPage> {
       var spec = cal.KeySpec(
           cipher: _cipherChoice!,
           signingHash: cal.CryptoHash.sha2256,
-          ephemeral: false);
+          ephemeral: false,
+          nonExportable: false);
       var key = await (await widget.provider!).createKey(spec: spec);
       setState(() {
         _keyHandle = key;

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -97,6 +97,8 @@ pub struct KeySpec {
     pub signing_hash: CryptoHash,
     /// If set to `true`, the key is going to be deleted when the handle is dropped.
     pub ephemeral: bool,
+    /// If set to `true`, the key cannot be exported.
+    pub non_exportable: bool,
 }
 
 /// Struct used to configure key pairs.

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -70,6 +70,9 @@ pub enum CalErrorKind {
         internal: bool,
     },
 
+    #[error("Key or key pair is non exportable.")]
+    NonExportable,
+
     /// Algorithm requested is not supported by the provider.
     #[error("Unsupported Algorithm: {0}")]
     UnsupportedAlgorithm(String),
@@ -179,6 +182,13 @@ impl CalError {
                 internal: true,
             },
             source: anyhow!("Initialization Error"),
+        }
+    }
+
+    pub(crate) fn non_exportable() -> Self {
+        Self {
+            error_kind: CalErrorKind::NonExportable,
+            source: anyhow!("NonExportable Error"),
         }
     }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -220,7 +220,7 @@ pub struct KeyPairHandle {
 /// Abstraction of asymmetric key pair handles.
 impl KeyPairHandle {
     delegate_enum! {
-        pub fn encrypt_data(&self, data: &[u8], iv: &[u8]) -> Result<Vec<u8>, CalError>;
+        pub fn encrypt_data(&self, data: &[u8]) -> Result<Vec<u8>, CalError>;
     }
 
     delegate_enum! {

--- a/src/common/traits/key_handle.rs
+++ b/src/common/traits/key_handle.rs
@@ -132,7 +132,7 @@ pub(crate) trait KeyPairHandleImpl: Send + Sync {
     ///
     /// # Returns
     /// A `Result` containing the encrypted data as a `Vec<u8>` on success, or a `CalError` on failure.
-    fn encrypt_data(&self, data: &[u8], iv: &[u8]) -> Result<Vec<u8>, CalError>;
+    fn encrypt_data(&self, data: &[u8]) -> Result<Vec<u8>, CalError>;
 
     /// Decrypts the given encrypted data using the cryptographic key.
     ///

--- a/src/software/key_handle.rs
+++ b/src/software/key_handle.rs
@@ -321,7 +321,11 @@ impl KeyHandleImpl for SoftwareKeyHandle {
     }
 
     fn extract_key(&self) -> Result<Vec<u8>, CalError> {
-        Ok(self.key.clone())
+        if self.spec.non_exportable {
+            Err(CalError::non_exportable())
+        } else {
+            Ok(self.key.clone())
+        }
     }
 
     fn id(&self) -> Result<String, CalError> {
@@ -432,11 +436,7 @@ impl KeyPairHandleImpl for SoftwareKeyPairHandle {
                 .clone()
                 .ok_or_else(|| CalError::missing_key(self.key_id.clone(), KeyType::Private))
         } else {
-            Err(CalError::failed_operation(
-                "The private key is not exportable".to_string(),
-                true,
-                None,
-            ))
+            Err(CalError::non_exportable())
         }
     }
 

--- a/src/software/key_handle.rs
+++ b/src/software/key_handle.rs
@@ -414,12 +414,12 @@ impl KeyPairHandleImpl for SoftwareKeyPairHandle {
         }
     }
 
-    fn encrypt_data(&self, _data: &[u8], _iv: &[u8]) -> Result<Vec<u8>, CalError> {
-        todo!("Encryption not supported for ECC keys")
+    fn encrypt_data(&self, _data: &[u8]) -> Result<Vec<u8>, CalError> {
+        Err(CalError::not_implemented())
     }
 
     fn decrypt_data(&self, _encrypted_data: &[u8]) -> Result<Vec<u8>, CalError> {
-        todo!("Decryption not supported for ECC keys")
+        Err(CalError::not_implemented())
     }
 
     fn get_public_key(&self) -> Result<Vec<u8>, CalError> {

--- a/src/software/provider.rs
+++ b/src/software/provider.rs
@@ -914,6 +914,7 @@ impl SoftwareDHExchange {
                 cipher,
                 ephemeral: self.spec.ephemeral,
                 signing_hash: self.spec.signing_hash,
+                non_exportable: self.spec.non_exportable,
             },
         };
 

--- a/src/stub/mod.rs
+++ b/src/stub/mod.rs
@@ -130,7 +130,7 @@ impl KeyPairHandleImpl for StubKeyPairHandle {
         Ok(data == signature)
     }
 
-    fn encrypt_data(&self, data: &[u8], iv: &[u8]) -> Result<Vec<u8>, CalError> {
+    fn encrypt_data(&self, data: &[u8]) -> Result<Vec<u8>, CalError> {
         todo!()
     }
 

--- a/src/tests/software/key_handle_tests.rs
+++ b/src/tests/software/key_handle_tests.rs
@@ -252,7 +252,7 @@ mod tests {
         }
     }
     mod key_handle {
-        use crate::tests::TestStore;
+        use crate::{prelude::CalErrorKind, tests::TestStore};
         use test_case::test_case;
 
         use super::*;
@@ -518,7 +518,7 @@ mod tests {
             let software_key_handle = create_software_key_handle(spec)?;
 
             let short_data = vec![0u8; 10];
-            let mut nonce = vec![0u8; spec.cipher.iv_len()];
+            let nonce = vec![0u8; spec.cipher.iv_len()];
 
             let decrypted_result = software_key_handle.decrypt_data(&short_data, &nonce);
 
@@ -594,6 +594,40 @@ mod tests {
 
             assert_eq!(received_message, payload);
             assert_eq!(derived_key.id()?, id);
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_extract_key() -> Result<()> {
+            setup();
+
+            let spec = KeySpec {
+                non_exportable: false,
+                ..Default::default()
+            };
+
+            let key = create_software_key_handle(spec)?;
+
+            let raw_key = key.extract_key()?;
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_extract_key_non_exportable() -> Result<()> {
+            setup();
+
+            let spec = KeySpec {
+                non_exportable: true,
+                ..Default::default()
+            };
+
+            let key = create_software_key_handle(spec)?;
+
+            let error = key.extract_key().unwrap_err();
+
+            assert!(matches!(error.error_kind(), CalErrorKind::NonExportable));
 
             Ok(())
         }

--- a/src/tests/software/provider_tests.rs
+++ b/src/tests/software/provider_tests.rs
@@ -190,6 +190,7 @@ mod tests {
                         cipher: Cipher::AesGcm256,
                         ephemeral: true,
                         signing_hash: CryptoHash::Sha2_256,
+                        non_exportable: false,
                     },
                 };
                 let client_tx_key_handle = KeyHandle {
@@ -205,6 +206,7 @@ mod tests {
                         cipher: Cipher::AesGcm256,
                         ephemeral: true,
                         signing_hash: CryptoHash::Sha2_256,
+                        non_exportable: false,
                     },
                 };
                 let server_rx_key_handle = KeyHandle {
@@ -236,6 +238,7 @@ mod tests {
                         cipher: Cipher::AesGcm256,
                         ephemeral: true,
                         signing_hash: CryptoHash::Sha2_256,
+                        non_exportable: false,
                     },
                 };
                 let server_tx_key_handle = KeyHandle {
@@ -251,6 +254,7 @@ mod tests {
                         cipher: Cipher::AesGcm256,
                         ephemeral: true,
                         signing_hash: CryptoHash::Sha2_256,
+                        non_exportable: false,
                     },
                 };
                 let client_rx_key_handle = KeyHandle {
@@ -472,6 +476,7 @@ mod tests {
                 cipher: Cipher::XChaCha20Poly1305,
                 signing_hash: CryptoHash::Sha2_256,
                 ephemeral: true,
+                non_exportable: false,
             }
         }
 

--- a/src/tests/tpm/apple_secure_enclave/mod.rs
+++ b/src/tests/tpm/apple_secure_enclave/mod.rs
@@ -15,9 +15,8 @@ static STORE: LazyLock<TestStore> = LazyLock::new(|| TestStore::new());
 fn test_create_apple_secure_provider_from_name() -> Result<()> {
     setup();
 
-    let _provider =
-        create_provider_from_name("APPLE_SECURE_ENCLAVE".to_owned(), STORE.impl_config())
-            .expect("Failed initializing apple secure provider.");
+    let _provider = create_provider_from_name("APPLE_SECURE_ENCLAVE", STORE.impl_config())
+        .expect("Failed initializing apple secure provider.");
 
     Ok(())
 }
@@ -26,15 +25,15 @@ fn test_create_apple_secure_provider_from_name() -> Result<()> {
 fn test_create_key_with_provider() -> Result<()> {
     setup();
 
-    let mut provider =
-        create_provider_from_name("APPLE_SECURE_ENCLAVE".to_owned(), STORE.impl_config())
-            .expect("Failed initializing apple secure provider.");
+    let mut provider = create_provider_from_name("APPLE_SECURE_ENCLAVE", STORE.impl_config())
+        .expect("Failed initializing apple secure provider.");
 
     let key_spec = KeyPairSpec {
         asym_spec: AsymmetricKeySpec::P256,
         cipher: None,
         signing_hash: CryptoHash::Sha2_256,
         ephemeral: false,
+        non_exportable: true,
     };
 
     let _key = provider.create_key_pair(key_spec)?;
@@ -48,9 +47,8 @@ fn test_create_key_with_provider() -> Result<()> {
 fn test_create_key_pair_sign_and_verify_data() -> Result<()> {
     setup();
 
-    let mut provider =
-        create_provider_from_name("APPLE_SECURE_ENCLAVE".to_owned(), STORE.impl_config())
-            .expect("Failed initializing apple secure provider.");
+    let mut provider = create_provider_from_name("APPLE_SECURE_ENCLAVE", STORE.impl_config())
+        .expect("Failed initializing apple secure provider.");
 
     let hashes = vec![
         CryptoHash::Sha2_224,
@@ -65,6 +63,7 @@ fn test_create_key_pair_sign_and_verify_data() -> Result<()> {
             cipher: None,
             signing_hash: hash,
             ephemeral: false,
+            non_exportable: true,
         };
 
         let key = provider.create_key_pair(key_spec)?;
@@ -87,15 +86,15 @@ fn test_load_key_pair() -> Result<()> {
     let id;
     let _key_cleanup;
     {
-        let mut provider =
-            create_provider_from_name("APPLE_SECURE_ENCLAVE".to_owned(), STORE.impl_config())
-                .expect("Failed initializing apple secure provider.");
+        let mut provider = create_provider_from_name("APPLE_SECURE_ENCLAVE", STORE.impl_config())
+            .expect("Failed initializing apple secure provider.");
 
         let key_spec = KeyPairSpec {
             asym_spec: AsymmetricKeySpec::P256,
             cipher: None,
             signing_hash: CryptoHash::Sha2_256,
             ephemeral: false,
+            non_exportable: true,
         };
 
         let key = provider.create_key_pair(key_spec)?;
@@ -104,9 +103,8 @@ fn test_load_key_pair() -> Result<()> {
         id = key.id()?;
     }
 
-    let mut provider =
-        create_provider_from_name("APPLE_SECURE_ENCLAVE".to_owned(), STORE.impl_config())
-            .expect("Failed initializing apple secure provider.");
+    let mut provider = create_provider_from_name("APPLE_SECURE_ENCLAVE", STORE.impl_config())
+        .expect("Failed initializing apple secure provider.");
 
     let key = provider.load_key_pair(id.clone())?;
 

--- a/src/tpm/android/key_handle.rs
+++ b/src/tpm/android/key_handle.rs
@@ -198,7 +198,7 @@ impl KeyPairHandleImpl for AndroidKeyPairHandle {
         Ok(output)
     }
 
-    fn encrypt_data(&self, encrypted_data: &[u8], iv: &[u8]) -> Result<Vec<u8>, CalError> {
+    fn encrypt_data(&self, encrypted_data: &[u8]) -> Result<Vec<u8>, CalError> {
         info!("encrypting");
 
         let vm = context::android_context()?.vm();

--- a/src/tpm/android/key_handle.rs
+++ b/src/tpm/android/key_handle.rs
@@ -101,19 +101,19 @@ impl KeyHandleImpl for AndroidKeyHandle {
     }
 
     fn hmac(&self, data: &[u8]) -> Result<Vec<u8>, CalError> {
-        todo!()
+        Err(CalError::not_implemented())
     }
 
     fn verify_hmac(&self, _data: &[u8], _hmac: &[u8]) -> Result<bool, CalError> {
-        todo!()
+        Err(CalError::not_implemented())
     }
 
     fn derive_key(&self, nonce: &[u8]) -> Result<KeyHandle, CalError> {
-        todo!();
+        Err(CalError::not_implemented())
     }
 
     fn extract_key(&self) -> Result<Vec<u8>, CalError> {
-        todo!()
+        Err(CalError::not_implemented())
     }
 
     fn delete(mut self) -> Result<(), CalError> {
@@ -277,11 +277,11 @@ impl KeyPairHandleImpl for AndroidKeyPairHandle {
     }
 
     fn extract_key(&self) -> Result<Vec<u8>, CalError> {
-        todo!()
+        Err(CalError::not_implemented())
     }
 
     fn start_dh_exchange(&self) -> Result<DHExchange, CalError> {
-        todo!()
+        Err(CalError::not_implemented())
     }
 
     fn delete(mut self) -> Result<(), CalError> {

--- a/src/tpm/apple_secure_enclave/key_handle.rs
+++ b/src/tpm/apple_secure_enclave/key_handle.rs
@@ -56,7 +56,7 @@ impl KeyPairHandleImpl for AppleSecureEnclaveKeyPair {
             .err_internal()
     }
 
-    fn encrypt_data(&self, _data: &[u8], iv: &[u8]) -> Result<Vec<u8>, CalError> {
+    fn encrypt_data(&self, _data: &[u8]) -> Result<Vec<u8>, CalError> {
         Err(CalError::not_implemented())
     }
 

--- a/ts-types/generated/CalErrorKind.ts
+++ b/ts-types/generated/CalErrorKind.ts
@@ -44,6 +44,7 @@ export type CalErrorKind =
       internal: boolean;
     };
   }
+  | "NonExportable"
   | { "UnsupportedAlgorithm": string }
   | "EphemeralKeyError"
   | "Other";

--- a/ts-types/generated/KeySpec.ts
+++ b/ts-types/generated/KeySpec.ts
@@ -19,4 +19,8 @@ export type KeySpec = {
    * If set to `true`, the key is going to be deleted when the handle is dropped.
    */
   ephemeral: boolean;
+  /**
+   * If set to `true`, the key cannot be exported.
+   */
+  non_exportable: boolean;
 };

--- a/ts-types/manual/KeyPairHandle.ts
+++ b/ts-types/manual/KeyPairHandle.ts
@@ -2,7 +2,7 @@ import type { KeyPairSpec } from "../generated/index.ts";
 import type { DHExchange } from "./DHExchange.ts";
 
 export type KeyPairHandle = {
-	encryptData: (data: Uint8Array, iv: Uint8Array) => Promise<Uint8Array>;
+	encryptData: (data: Uint8Array) => Promise<Uint8Array>;
 	decryptData: (encryptedData: Uint8Array) => Promise<Uint8Array>;
 	signData: (data: Uint8Array) => Promise<Uint8Array>;
 	verifySignature: (

--- a/ts-types/package-lock.json
+++ b/ts-types/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nmshd/rs-crypto-types",
-			"version": "0.9.0",
+			"version": "0.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"typia": "^8.0.3"

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"description": "Crypto Layer TS type definitions.",
 	"homepage": "https://enmeshed.eu",
 	"repository": "github:nmshd/rust-crypto",


### PR DESCRIPTION
### Added:
* `non_exportable` flag for `KeySpec`.

### Fixed
* Dart code gen not generating bindings correctly, when api changed.

### Changed:
* Removed `iv` argument of `encrypt_data` of `KeyPairHandle`.
* ts types version bump.

### Removed:

### Checklist:

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [x] Are changes in common propagated to all providers that are currently in use?
    -   [x] `software`
    -   [x] `tpm/android`
    -   [x] `tpm/apple_secure_enclave`
-   [x] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [x] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [x] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [x] Does the flutter plugin still compile?
-   [x] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
