### PR TITLE
fix(flutter_plugin): missing import after `task generate`

### DIFF
--- a/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common/factory.dart
+++ b/cal_flutter_plugin/lib/src/rust/third_party/crypto_layer/common/factory.dart
@@ -22,10 +22,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 /// ```
 /// use std::collections::HashSet;
 ///
-/// use crypto_layer::common::{
-///     config::*,
-///     factory::*,
-/// };
+/// use crypto_layer::prelude::*;
 ///
 /// let specific_provider_config = ProviderImplConfig{additional_config: vec![]};
 /// let provider_config = ProviderConfig {
@@ -35,7 +32,8 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 ///     supported_ciphers: HashSet::new(),
 ///     supported_hashes: HashSet::new(),
 /// };
-/// let provider = create_provider(&provider_config, specific_provider_config).unwrap();
+///
+/// let provider_option: Option<Provider> = create_provider(&provider_config, specific_provider_config);
 /// ```
 Future<Provider?> createProvider({
   required ProviderConfig conf,

--- a/cal_flutter_plugin/rust/src/api/crypto.rs
+++ b/cal_flutter_plugin/rust/src/api/crypto.rs
@@ -1,4 +1,4 @@
-use crypto_layer::common::config::ProviderImplConfig;
+use crypto_layer::{common::config::ProviderImplConfig, prelude::AdditionalConfig};
 
 use flutter_rust_bridge::DartFnFuture;
 use std::sync::Arc;


### PR DESCRIPTION
### Added:

### Changed:
fix missing use statement in flutter_plugin
### Removed:

### Checklist:

-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
