### PR TITLE
fix(software): fix bug when deriving key ids

### DIFF
--- a/src/provider/android/key_handle.rs
+++ b/src/provider/android/key_handle.rs
@@ -180,7 +180,7 @@ impl KeyHandleImpl for AndroidKeyHandle {
                 cal_err
             })?;
 
-        let id = id_from_buffer(nonce);
+        let id = id_from_buffer(self.key_id.as_bytes(), nonce);
 
         let jderived_key = env.byte_array_from_slice(&derived_key).err_internal()?;
         let algorithm = get_cipher_name(spec.cipher)?;

--- a/src/provider/android/provider.rs
+++ b/src/provider/android/provider.rs
@@ -24,7 +24,7 @@ use anyhow::anyhow;
 use itertools::Itertools;
 use nanoid::nanoid;
 use robusta_jni::jni::JavaVM;
-use std::{collections::HashSet, fmt::Debug};
+use std::fmt::Debug;
 use tracing::{info, instrument};
 
 #[derive(Debug, Clone, Copy)]

--- a/src/provider/software/key_handle.rs
+++ b/src/provider/software/key_handle.rs
@@ -64,13 +64,14 @@ impl SoftwareKeyHandle {
 /// Hashes and encodes a buffer to a string.
 ///
 /// This is meant to generate deterministic ids from variable length nonces and contexts in derive key.
-pub(crate) fn id_from_buffer(buff: &[u8]) -> String {
+pub(crate) fn id_from_buffer(id: &[u8], buff: &[u8]) -> String {
     // `digest` and `blake2` crate have both update functions that get each other in the way.
     use blake2::{digest::consts::U8, Blake2b, Digest};
 
     type Blake2b64 = Blake2b<U8>;
 
     let mut hasher = <Blake2b64 as Digest>::new();
+    hasher.update(id);
     hasher.update(buff);
     let hash = hasher.finalize();
     let hash_vec = hash.to_vec();
@@ -338,7 +339,7 @@ impl KeyHandleImpl for SoftwareKeyHandle {
                 cal_err
             })?;
 
-        let id = id_from_buffer(nonce);
+        let id = id_from_buffer(self.key_id.as_bytes(), nonce);
 
         Ok(KeyHandle {
             implementation: SoftwareKeyHandle::new(id, spec, derived_key, None)

--- a/src/provider/software/provider.rs
+++ b/src/provider/software/provider.rs
@@ -34,7 +34,7 @@ use ring::{
     signature::{EcdsaKeyPair, EcdsaSigningAlgorithm, KeyPair},
 };
 use sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512};
-use tracing::{error, info, trace};
+use tracing::{error, info};
 use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
 
 impl ProviderImpl for SoftwareProvider {

--- a/src/storage/storage_backend/file_store.rs
+++ b/src/storage/storage_backend/file_store.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, path::Path};
 use itertools::Itertools;
 use sled::{open, Db};
 use thiserror::Error;
-use tracing::{trace, warn};
 
 use crate::storage::key::ScopedKey;
 use crate::storage::storage_backend::StorageBackendInitializationError;
@@ -138,8 +137,7 @@ impl StorageBackend for FileStorageBackend {
         match self
             .db
             .get(key)
-            .map_err(|err| FileStorageBackendError::Get { source: err })
-            .inspect_err(|e| {})?
+            .map_err(|err| FileStorageBackendError::Get { source: err })?
         {
             Some(data) => Ok(data.as_ref().to_vec()),
             None => Err(FileStorageBackendError::NotExists.into()),


### PR DESCRIPTION
### Added:

### Changed:

### Removed:

### Checklist:

-   [ ] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [ ] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
