### PR TITLE
feat: add apple os logs to flutter plugin

### DIFF
--- a/cal_flutter_plugin/rust/Cargo.toml
+++ b/cal_flutter_plugin/rust/Cargo.toml
@@ -14,7 +14,7 @@ libloading = "0.8.5"
 tracing = { version = "0.1.40", features = ["attributes"] }
 tracing-subscriber = "0.3.18"
 anyhow = "1.0.91"
-crypto-layer = { path = "../../", features = ["software"]}
+crypto-layer = { path = "../../", features = ["software"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-android = { version = "0.2.0" }
@@ -23,7 +23,11 @@ jni = "0.19"
 ndk-context = "0.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-crypto-layer = { path = "../../", features = ["apple-secure-enclave"] }
+crypto-layer = { path = "../../", features = [
+    "apple-secure-enclave",
+    "software",
+] }
+tracing-oslog = "0.3.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/cal_flutter_plugin/rust/src/api/simple.rs
+++ b/cal_flutter_plugin/rust/src/api/simple.rs
@@ -12,7 +12,12 @@ pub(super) fn set_up_logging() {
     #[cfg(target_os = "android")]
     let subscriber = Registry::default()
         .with(tracing_android::layer("RUST").expect("could not create android logger"));
-    #[cfg(not(target_os = "android"))]
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    let subscriber = Registry::default().with(tracing_oslog::OsLogger::default());
+
+    #[cfg(not(any(target_os = "android", target_os = "macos", target_os = "ios")))]
     let subscriber = Registry::default();
+
     let _ = tracing::subscriber::set_global_default(subscriber);
 }


### PR DESCRIPTION
### Added:
* Experimental logs on iOS and MacOS.

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [x] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
