### PR TITLE
Fix(ts-types): vulnerable dependency

### DIFF
--- a/ts-types/package-lock.json
+++ b/ts-types/package-lock.json
@@ -189,9 +189,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.14.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+			"version": "22.17.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
+			"integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -770,15 +770,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/package-manager-detector": {
 			"version": "0.2.11",
 			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
@@ -935,9 +926,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -1020,15 +1011,12 @@
 			"license": "MIT"
 		},
 		"node_modules/tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
+			"integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
 			"license": "MIT",
-			"dependencies": {
-				"os-tmpdir": "~1.0.2"
-			},
 			"engines": {
-				"node": ">=0.6.0"
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/ts-patch": {

--- a/ts-types/package-lock.json
+++ b/ts-types/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nmshd/rs-crypto-types",
-			"version": "0.12.0",
+			"version": "0.12.1",
 			"license": "MIT",
 			"dependencies": {
 				"typia": "^8.0.3"

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -29,5 +29,9 @@
 	},
 	"dependencies": {
 		"typia": "^8.0.3"
+	},
+	"overrides": {
+		"tmp": "^0.2.1",
+		"@types/tmp": "^0.2.0"
 	}
 }

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nmshd/rs-crypto-types",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"description": "Crypto Layer TS type definitions.",
 	"homepage": "https://enmeshed.eu",
 	"repository": "github:nmshd/rust-crypto",


### PR DESCRIPTION
### Fixed:

* 	Override vulnerable dependency.
	(ts-types depends on `typia`, which depends on `inquirer`, which depends on `external-editor`, which depends on the vulnerable `tmp:0.0.33`.)
