### PR TITLE
Revert: use of connection pool for sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,12 +384,11 @@ dependencies = [
  "nanoid",
  "p256",
  "pollster",
- "r2d2",
- "r2d2_sqlite",
  "ring",
  "rmp-serde",
  "robusta_jni",
  "rstest",
+ "rusqlite",
  "rusqlite_migration",
  "security-framework",
  "security-framework-sys",
@@ -1356,17 +1355,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.9.11",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1378,22 +1367,9 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
  "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.5.17",
- "smallvec",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1608,28 +1584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r2d2"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
-dependencies = [
- "log",
- "parking_lot 0.12.4",
- "scheduled-thread-pool",
-]
-
-[[package]]
-name = "r2d2_sqlite"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63417e83dc891797eea3ad379f52a5986da4bca0d6ef28baf4d14034dd111b0c"
-dependencies = [
- "r2d2",
- "rusqlite",
- "uuid",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,15 +1649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1939,15 +1884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot 0.12.4",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,7 +2047,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2676,18 +2612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "uuid"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
-dependencies = [
- "getrandom 0.3.3",
- "js-sys",
- "rand 0.9.1",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,7 +2662,6 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,7 @@ itertools = "0.14.0"
 rmp-serde = "1.3.0"
 security-framework-sys = { version = "2.14.0", optional = true }
 rusqlite_migration = "2.3.0"
-r2d2 = "0.8.10"
-r2d2_sqlite = { version = "0.31.0", features = ["bundled"] }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
 
 [dev-dependencies]
 color-eyre = "0.6.3"


### PR DESCRIPTION
### Removed:

* Removed r2d2 connection pool, due to being much slower (10%).


### Checklist:

-   [x] Do the unit tests in CAL run? Check at least those that you can run: `cargo test -F software`
-   [ ] Are changes in common propagated to all providers that are currently in use?
    -   [ ] `software`
    -   [ ] `tpm/android`
    -   [ ] `tpm/apple_secure_enclave`
-   [ ] Did changes in the API occur, such that `./ts-types` needs to be updated?
    -   [ ] [Generate types partially](https://github.com/nmshd/rust-crypto/tree/main/ts-types#generate-the-types).
    -   [ ] Have you given the maintainer of [`crypto-layer-node`](https://github.com/nmshd/crypto-layer-node) a heads up?
-   [ ] Do the dart bindings have to be [re-generated](https://github.com/nmshd/rust-crypto/tree/main/flutter_plugin#generating-dart-bindings)?
-   [ ] Does the flutter plugin still compile?
-   [ ] Do the integration tests in flutter-app still [run](https://github.com/nmshd/rust-crypto/tree/main/flutter_app#running-the-app)?
-   [x] There are no build artifacts in the commit. (`node_modules`, `lib`, `target` and everything in `.gitignore`)
